### PR TITLE
Use search domains instead of routing domains in resolvectl command

### DIFF
--- a/src/model/wrappers.rs
+++ b/src/model/wrappers.rs
@@ -79,6 +79,7 @@ impl<'de> Deserialize<'de> for QuotedStringList {
             String::deserialize(deserializer)?
                 .trim_matches('"')
                 .split(',')
+                .map(|s| s.trim())
                 .map(ToOwned::to_owned)
                 .collect(),
         ))

--- a/src/platform/linux/net.rs
+++ b/src/platform/linux/net.rs
@@ -151,10 +151,7 @@ where
 {
     let mut args = vec!["domain", device];
 
-    let suffixes = suffixes
-        .into_iter()
-        .map(|s| format!("~{}", s.as_ref()))
-        .collect::<Vec<_>>();
+    let suffixes = suffixes.into_iter().map(|s| s.as_ref().to_owned()).collect::<Vec<_>>();
 
     args.extend(suffixes.iter().map(|s| s.as_str()));
 


### PR DESCRIPTION
Hi,
this PR fixes two problem with assigning dns domains for vpn interface:

1. At my company checkpoint returns dns servers with trailing whitespaces. Current snx-rs implementation pushes them to resolvectl in following format:
`DNS Domain: ~some.domain ~\032other.domain`
I modified deserialize for `QuotedStringList` to trim whitespaces from Vec members.
2. **systemd-resolved** has two modes to serve `DNS Domain:` settings:
    - routing domains - records prefixed with `~`. If _resolved_ gets request to resolve domain with such suffix, it **only forwards** request to dns server of corresponding interface.
    - search domains - records not prefixed with `~`. Such domains are also used to suffix single-label domain names. Like if _resolved_ gets request `git` it can transform it to `git.some.domain` and resolve it's address. More detailed description is [here](https://systemd.io/RESOLVED-VPNS/)

It's quite common to have single-label domain links in corporate systems, so using search domains seems logical hear. This PR removes addition of `~` in front of domain suffix. However if one wants to use routing domain, it can be achieved through `--search-domains` parameter usage.