### PR TITLE
Fix password prompt for no-keychain and fix infinite challenge requests with no-keychain 

### DIFF
--- a/src/bin/snx-rs.rs
+++ b/src/bin/snx-rs.rs
@@ -62,6 +62,13 @@ async fn main() -> anyhow::Result<()> {
                 return Err(anyhow!("Missing required parameters: server name and/or login type"));
             }
 
+            if params.password.is_empty() && params.client_cert.is_none() {
+                params.password = SecurePrompt::tty()
+                    .get_secure_input(&format!("Enter password for {}: ", params.user_name))?
+                    .trim()
+                    .to_owned();
+            }
+
             let connector = TunnelConnector::new(Arc::new(params));
             let mut session = Arc::new(connector.authenticate().await?);
 

--- a/src/bin/snx-rs.rs
+++ b/src/bin/snx-rs.rs
@@ -84,7 +84,9 @@ async fn main() -> anyhow::Result<()> {
                 warn!("Unable to start network monitoring: {}", e);
             }
 
-            Box::pin(tunnel.run(rx, status))
+            let (status_sender, _) = oneshot::channel();
+            let result = Box::pin(tunnel.run(rx, status, status_sender));
+            result
         }
         OperationMode::Command => {
             debug!("Running in command mode");

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -124,8 +124,7 @@ impl ServiceController {
                 if let Ok(password) = platform::acquire_password(&params.user_name).await {
                     params.password = password;
                 }
-            }
-            if params.password.is_empty() && !params.no_keychain {
+            } else {
                 params.password = self
                     .prompt
                     .get_secure_input(&format!("Enter password for {}: ", params.user_name))?

--- a/src/model/wrappers.rs
+++ b/src/model/wrappers.rs
@@ -79,7 +79,6 @@ impl<'de> Deserialize<'de> for QuotedStringList {
             String::deserialize(deserializer)?
                 .trim_matches('"')
                 .split(',')
-                .map(|s| s.trim())
                 .map(ToOwned::to_owned)
                 .collect(),
         ))

--- a/src/platform/linux/net.rs
+++ b/src/platform/linux/net.rs
@@ -151,7 +151,7 @@ where
 {
     let mut args = vec!["domain", device];
 
-    let suffixes = suffixes.into_iter().map(|s| s.as_ref().to_owned()).collect::<Vec<_>>();
+    let suffixes = suffixes.into_iter().map(|s| s.as_ref().trim().to_owned()).collect::<Vec<_>>();
 
     args.extend(suffixes.iter().map(|s| s.as_str()));
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -23,6 +23,7 @@ pub trait CheckpointTunnel {
         mut self: Box<Self>,
         stop_receiver: oneshot::Receiver<()>,
         connected: Arc<Mutex<ConnectionStatus>>,
+        status_sender: oneshot::Sender<()>,
     ) -> anyhow::Result<()>;
 }
 

--- a/src/tunnel/ipsec.rs
+++ b/src/tunnel/ipsec.rs
@@ -94,6 +94,7 @@ impl CheckpointTunnel for IpsecTunnel {
         self: Box<Self>,
         stop_receiver: oneshot::Receiver<()>,
         connected: Arc<Mutex<ConnectionStatus>>,
+        status_sender: oneshot::Sender<()>,
     ) -> anyhow::Result<()> {
         debug!("Running IPSec tunnel");
 
@@ -103,6 +104,9 @@ impl CheckpointTunnel for IpsecTunnel {
             connected_since: Some(Local::now()),
             ..Default::default()
         };
+        if status_sender.send(()).is_ok() {
+            debug!("IPSec tunnel connection status set")
+        }
 
         let result = tokio::select! {
             _ = stop_receiver => {

--- a/src/tunnel/ssl.rs
+++ b/src/tunnel/ssl.rs
@@ -189,6 +189,7 @@ impl CheckpointTunnel for SslTunnel {
         mut self: Box<Self>,
         mut stop_receiver: oneshot::Receiver<()>,
         connected: Arc<Mutex<ConnectionStatus>>,
+        status_sender: oneshot::Sender<()>,
     ) -> anyhow::Result<()> {
         debug!("Running SSL tunnel for session {}", self.session.session_id);
 
@@ -239,6 +240,9 @@ impl CheckpointTunnel for SslTunnel {
             connected_since: Some(Local::now()),
             ..Default::default()
         };
+        if status_sender.send(()).is_ok() {
+            debug!("SSL tunnel connection status set")
+        }
 
         loop {
             tokio::select! {


### PR DESCRIPTION
Hi again.
This PR addresses several issues that I've faced since 0.10.0 release.

1. Commit 65b124f2e8cc8925e04ba7d154306f167033f5f5 fixes absence of password prompt in case of 'no-keychain' usage. Without it, snx-rs sends first request without password and then proceeds with `CommandServer::challenge_code()` logic.
2. Commit 00f99f5c96159ed7928ad34455663f14cea1629c addresses incorrect connection status check after **SSL** tunnel set up. Without it I get an extra password prompts from `CommandServer::challenge_code()` and an error:
   - Before: ![image](https://github.com/ancwrd1/snx-rs/assets/6929041/a2caf45a-07d8-44c5-915c-6ea96df8c710)
   - After: ![image](https://github.com/ancwrd1/snx-rs/assets/6929041/4b9700e4-720d-4967-9ec1-0cf0a6b83e14)
  This does not happen when using **Ipsec** tunnel though...
3. Commit 216eb8123378366a749efbfad8c85067fc12927c adds fancy password prompt for standalone mode.
4. Last commit fixes regression of #8 fix. Don't know why, but trim in quoted string deserialization just stopped working.