### PR TITLE
Add possibility to fetch password prompts text from server (default on)

### DIFF
--- a/src/bin/snx-rs.rs
+++ b/src/bin/snx-rs.rs
@@ -1,9 +1,11 @@
 use std::{future::Future, pin::Pin, sync::Arc, sync::Mutex};
+use std::collections::VecDeque;
 
 use anyhow::anyhow;
 use base64::Engine;
 use clap::Parser;
 use futures::pin_mut;
+use serde_json::Value;
 use tokio::{signal::unix, sync::oneshot};
 use tracing::{debug, metadata::LevelFilter, warn};
 
@@ -17,6 +19,7 @@ use snx_rs::{
     server::CommandServer,
     tunnel::TunnelConnector,
 };
+use snx_rs::model::proto::{LoginDisplayLabelSelect, ServerInfoResponse};
 
 fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
@@ -61,10 +64,13 @@ async fn main() -> anyhow::Result<()> {
             if params.server_name.is_empty() || params.login_type.is_empty() {
                 return Err(anyhow!("Missing required parameters: server name and/or login type"));
             }
+            
+            let mut pwd_prompts = get_server_pwd_prompts(&params).await.unwrap_or_default();
 
             if params.password.is_empty() && params.client_cert.is_none() {
+                let prompt = pwd_prompts.pop_front().unwrap_or(format!("Enter password for {}: ", params.user_name));
                 params.password = SecurePrompt::tty()
-                    .get_secure_input(&format!("Enter password for {}: ", params.user_name))?
+                    .get_secure_input(&prompt)?
                     .trim()
                     .to_owned();
             }
@@ -72,9 +78,9 @@ async fn main() -> anyhow::Result<()> {
             let connector = TunnelConnector::new(Arc::new(params));
             let mut session = Arc::new(connector.authenticate().await?);
 
-            while let SessionState::Pending { ref prompt } = session.state {
-                let prompt = prompt.as_deref().unwrap_or("Multi-factor code: ");
-                match SecurePrompt::tty().get_secure_input(prompt) {
+            while let SessionState::Pending { prompt } = session.state.clone() {
+                let prompt =  pwd_prompts.pop_front().unwrap_or(prompt.unwrap_or("Multi-factor code: ".to_string()));
+                match SecurePrompt::tty().get_secure_input(&prompt) {
                     Ok(input) => {
                         session = Arc::new(connector.challenge_code(session, &input).await?);
                     }
@@ -139,4 +145,36 @@ async fn main() -> anyhow::Result<()> {
     debug!("<<< Stopping snx-rs client");
 
     result
+}
+
+async fn get_server_info(params: &TunnelParams) -> anyhow::Result<ServerInfoResponse> {
+    let client = CccHttpClient::new(Arc::new(params.clone()), None);
+    let info = client.get_server_info().await?;
+    let response_data = info.get("ResponseData").unwrap_or(&Value::Null);
+    Ok(serde_json::from_value::<ServerInfoResponse>(response_data.clone())?)
+}
+
+async fn get_server_pwd_prompts(params: &TunnelParams) -> anyhow::Result<VecDeque<String>> {
+    let mut pwd_prompts = VecDeque::new();
+    if !params.server_prompt {
+        return Ok(pwd_prompts);
+    }
+    let server_info = get_server_info(params).await?;
+    let login_type = &params.login_type;
+    let login_factors = server_info
+        .login_options_data
+        .login_options_list
+        .iter()
+        .find(|login_option| login_option.id == *login_type)
+        .map(|login_option| login_option.to_owned())
+        .unwrap()
+        .factors;
+    login_factors
+        .iter()
+        .filter_map(|factor| match &factor.custom_display_labels {
+            LoginDisplayLabelSelect::LoginDisplayLabel(label) => Some(&label.password),
+            LoginDisplayLabelSelect::Empty(_) => None,
+        })
+        .for_each(|prompt| { pwd_prompts.push_back(format!("{}: ", prompt.0.clone())) });
+    Ok(pwd_prompts)
 }

--- a/src/bin/snx-rs.rs
+++ b/src/bin/snx-rs.rs
@@ -1,11 +1,12 @@
-use std::{future::Future, pin::Pin, sync::Arc, sync::Mutex};
-use std::collections::VecDeque;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
 
 use anyhow::anyhow;
-use base64::Engine;
 use clap::Parser;
 use futures::pin_mut;
-use serde_json::Value;
 use tokio::{signal::unix, sync::oneshot};
 use tracing::{debug, metadata::LevelFilter, warn};
 
@@ -15,11 +16,11 @@ use snx_rs::{
         params::{CmdlineParams, OperationMode, TunnelParams},
         ConnectionStatus, SessionState,
     },
+    platform,
     prompt::SecurePrompt,
     server::CommandServer,
     tunnel::TunnelConnector,
 };
-use snx_rs::model::proto::{LoginDisplayLabelSelect, ServerInfoResponse};
 
 fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
@@ -42,11 +43,7 @@ async fn main() -> anyhow::Result<()> {
     };
     params.merge(cmdline_params);
 
-    if !params.password.is_empty() {
-        // decode password
-        params.password =
-            String::from_utf8_lossy(&base64::engine::general_purpose::STANDARD.decode(&params.password)?).into_owned();
-    }
+    params.decode_password()?;
 
     let subscriber = tracing_subscriber::fmt()
         .with_max_level(params.log_level.parse::<LevelFilter>().unwrap_or(LevelFilter::OFF))
@@ -64,22 +61,23 @@ async fn main() -> anyhow::Result<()> {
             if params.server_name.is_empty() || params.login_type.is_empty() {
                 return Err(anyhow!("Missing required parameters: server name and/or login type"));
             }
-            
-            let mut pwd_prompts = get_server_pwd_prompts(&params).await.unwrap_or_default();
+
+            let mut pwd_prompts = platform::get_server_pwd_prompts(&params).await.unwrap_or_default();
 
             if params.password.is_empty() && params.client_cert.is_none() {
-                let prompt = pwd_prompts.pop_front().unwrap_or(format!("Enter password for {}: ", params.user_name));
-                params.password = SecurePrompt::tty()
-                    .get_secure_input(&prompt)?
-                    .trim()
-                    .to_owned();
+                let prompt = pwd_prompts
+                    .pop_front()
+                    .unwrap_or(format!("Enter password for {}: ", params.user_name));
+                params.password = SecurePrompt::tty().get_secure_input(&prompt)?.trim().to_owned();
             }
 
             let connector = TunnelConnector::new(Arc::new(params));
             let mut session = Arc::new(connector.authenticate().await?);
 
             while let SessionState::Pending { prompt } = session.state.clone() {
-                let prompt =  pwd_prompts.pop_front().unwrap_or(prompt.unwrap_or("Multi-factor code: ".to_string()));
+                let prompt = pwd_prompts
+                    .pop_front()
+                    .unwrap_or(prompt.unwrap_or("Multi-factor code: ".to_string()));
                 match SecurePrompt::tty().get_secure_input(&prompt) {
                     Ok(input) => {
                         session = Arc::new(connector.challenge_code(session, &input).await?);
@@ -93,7 +91,7 @@ async fn main() -> anyhow::Result<()> {
             let status = Arc::new(Mutex::new(ConnectionStatus::default()));
             let tunnel = connector.create_tunnel(session).await?;
 
-            if let Err(e) = snx_rs::platform::start_network_state_monitoring().await {
+            if let Err(e) = platform::start_network_state_monitoring().await {
                 warn!("Unable to start network monitoring: {}", e);
             }
 
@@ -104,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
         OperationMode::Command => {
             debug!("Running in command mode");
 
-            if let Err(e) = snx_rs::platform::start_network_state_monitoring().await {
+            if let Err(e) = platform::start_network_state_monitoring().await {
                 warn!("Unable to start network monitoring: {}", e);
             }
             let server = CommandServer::new(snx_rs::server::LISTEN_PORT);
@@ -145,36 +143,4 @@ async fn main() -> anyhow::Result<()> {
     debug!("<<< Stopping snx-rs client");
 
     result
-}
-
-async fn get_server_info(params: &TunnelParams) -> anyhow::Result<ServerInfoResponse> {
-    let client = CccHttpClient::new(Arc::new(params.clone()), None);
-    let info = client.get_server_info().await?;
-    let response_data = info.get("ResponseData").unwrap_or(&Value::Null);
-    Ok(serde_json::from_value::<ServerInfoResponse>(response_data.clone())?)
-}
-
-async fn get_server_pwd_prompts(params: &TunnelParams) -> anyhow::Result<VecDeque<String>> {
-    let mut pwd_prompts = VecDeque::new();
-    if !params.server_prompt {
-        return Ok(pwd_prompts);
-    }
-    let server_info = get_server_info(params).await?;
-    let login_type = &params.login_type;
-    let login_factors = server_info
-        .login_options_data
-        .login_options_list
-        .iter()
-        .find(|login_option| login_option.id == *login_type)
-        .map(|login_option| login_option.to_owned())
-        .unwrap()
-        .factors;
-    login_factors
-        .iter()
-        .filter_map(|factor| match &factor.custom_display_labels {
-            LoginDisplayLabelSelect::LoginDisplayLabel(label) => Some(&label.password),
-            LoginDisplayLabelSelect::Empty(_) => None,
-        })
-        .for_each(|prompt| { pwd_prompts.push_back(format!("{}: ", prompt.0.clone())) });
-    Ok(pwd_prompts)
 }

--- a/src/model/params.rs
+++ b/src/model/params.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use base64::Engine;
 use clap::Parser;
 use ipnet::Ipv4Net;
 use serde::{Deserialize, Serialize};
@@ -363,5 +364,13 @@ impl TunnelParams {
         if let Some(server_prompt) = other.server_prompt {
             self.server_prompt = server_prompt;
         }
+    }
+
+    pub fn decode_password(&mut self) -> anyhow::Result<()> {
+        if !self.password.is_empty() {
+            self.password = String::from_utf8_lossy(&base64::engine::general_purpose::STANDARD.decode(&self.password)?)
+                .into_owned();
+        }
+        Ok(())
     }
 }

--- a/src/model/params.rs
+++ b/src/model/params.rs
@@ -139,6 +139,14 @@ pub struct CmdlineParams {
         help = "Do not use OS keychain to store or retrieve user password"
     )]
     pub no_keychain: Option<bool>,
+
+    #[clap(
+        long = "server-prompt",
+        short = 'P',
+        default_value = "true",
+        help = "Ask server for authentication data prompt values"
+    )]
+    pub server_prompt: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -188,6 +196,7 @@ pub struct TunnelParams {
     pub cert_password: Option<String>,
     pub if_name: Option<String>,
     pub no_keychain: bool,
+    pub server_prompt: bool,
 }
 
 impl Default for TunnelParams {
@@ -213,6 +222,7 @@ impl Default for TunnelParams {
             cert_password: None,
             if_name: None,
             no_keychain: false,
+            server_prompt: true,
         }
     }
 }
@@ -258,6 +268,7 @@ impl TunnelParams {
                         "cert-password" => params.cert_password = Some(v),
                         "if-name" => params.if_name = Some(v),
                         "no-keychain" => params.no_keychain = v.parse().unwrap_or_default(),
+                        "server-prompt" => params.server_prompt = v.parse().unwrap_or_default(),
                         other => {
                             warn!("Ignoring unknown option: {}", other);
                         }
@@ -347,6 +358,10 @@ impl TunnelParams {
 
         if let Some(no_keychain) = other.no_keychain {
             self.no_keychain = no_keychain;
+        }
+
+        if let Some(server_prompt) = other.server_prompt {
+            self.server_prompt = server_prompt;
         }
     }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,7 +5,6 @@ use tokio::net::UdpSocket;
 
 #[cfg(target_os = "linux")]
 use linux as platform_impl;
-
 pub use platform_impl::{
     acquire_password,
     net::{
@@ -14,6 +13,7 @@ pub use platform_impl::{
     },
     new_tun_config, send_notification, store_password, IpsecImpl,
 };
+pub use server_info::{get as get_server_info, get_pwd_prompts as get_server_pwd_prompts};
 
 use crate::model::{
     params::TunnelParams,
@@ -21,7 +21,8 @@ use crate::model::{
 };
 
 #[cfg(target_os = "linux")]
-pub mod linux;
+mod linux;
+mod server_info;
 
 #[async_trait::async_trait]
 pub trait IpsecConfigurator {

--- a/src/platform/linux/net.rs
+++ b/src/platform/linux/net.rs
@@ -151,7 +151,10 @@ where
 {
     let mut args = vec!["domain", device];
 
-    let suffixes = suffixes.into_iter().map(|s| s.as_ref().trim().to_owned()).collect::<Vec<_>>();
+    let suffixes = suffixes
+        .into_iter()
+        .map(|s| s.as_ref().trim().to_owned())
+        .collect::<Vec<_>>();
 
     args.extend(suffixes.iter().map(|s| s.as_str()));
 

--- a/src/platform/server_info.rs
+++ b/src/platform/server_info.rs
@@ -1,0 +1,47 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use serde_json::Value;
+
+use crate::{
+    ccc::CccHttpClient,
+    model::{
+        params::TunnelParams,
+        proto::{LoginDisplayLabelSelect, ServerInfoResponse},
+    },
+};
+
+pub async fn get(params: &TunnelParams) -> anyhow::Result<ServerInfoResponse> {
+    let client = CccHttpClient::new(Arc::new(params.clone()), None);
+    let info = client.get_server_info().await?;
+    let response_data = info.get("ResponseData").unwrap_or(&Value::Null);
+    Ok(serde_json::from_value::<ServerInfoResponse>(response_data.clone())?)
+}
+
+pub async fn get_pwd_prompts(params: &TunnelParams) -> anyhow::Result<VecDeque<String>> {
+    let mut pwd_prompts = VecDeque::new();
+    if !params.server_prompt {
+        return Ok(pwd_prompts);
+    }
+    let server_info = get(params).await?;
+    let login_type = &params.login_type;
+    let login_factors = server_info
+        .login_options_data
+        .login_options_list
+        .into_iter()
+        .find_map(|login_option| {
+            if login_option.id == *login_type {
+                Some(login_option.factors)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+    login_factors
+        .into_iter()
+        .filter_map(|factor| match &factor.custom_display_labels {
+            LoginDisplayLabelSelect::LoginDisplayLabel(label) => Some(label.password.clone()),
+            LoginDisplayLabelSelect::Empty(_) => None,
+        })
+        .for_each(|prompt| pwd_prompts.push_back(format!("{}: ", prompt.0.clone())));
+    Ok(pwd_prompts)
+}


### PR DESCRIPTION
Hi again.
I hope this one is the last PR to get snx-rs ready for mass adoption at my company ) Kudos for the project!
Here I introduced possibility to fetch password prompts from server info. Windows ChackPoint client works same way, at least with our auth mechanisms - on connection initiation it first sends a `ClientHello` request and then populates prompts with data received.
The feature is guarded by `--server-prompt` flag, I made it on by default, but feel free to make it off by default.
Also, I implemented connection status request to the daemon in `ServiceController::do_info()`, as default disconnected status kind of bothered me )