### PR TITLE
Bugfix for certificate authentication when no additional MFA codes are needed

### DIFF
--- a/snx-rs/src/cmdline.rs
+++ b/snx-rs/src/cmdline.rs
@@ -152,6 +152,13 @@ pub struct CmdlineParams {
 
     #[clap(long = "ike-port", short = 'R', help = "IPSec IKE communication port [default: 500]")]
     pub ike_port: Option<u16>,
+
+    #[clap(
+        long = "client-mode",
+        short = 'C',
+        help = "Custom client mode [default: secure_connect]"
+    )]
+    pub client_mode: Option<String>,
 }
 
 impl CmdlineParams {
@@ -263,6 +270,10 @@ impl CmdlineParams {
 
         if let Some(ike_port) = self.ike_port {
             other.ike_port = ike_port;
+        }
+
+        if let Some(client_mode) = self.client_mode {
+            other.client_mode = client_mode;
         }
     }
 }

--- a/snxcore/src/model/params.rs
+++ b/snxcore/src/model/params.rs
@@ -160,6 +160,7 @@ pub struct TunnelParams {
     pub esp_lifetime: Duration,
     pub ike_lifetime: Duration,
     pub ike_port: u16,
+    pub client_mode: String,
     pub config_file: PathBuf,
 }
 
@@ -193,6 +194,7 @@ impl Default for TunnelParams {
             esp_lifetime: DEFAULT_ESP_LIFETIME,
             ike_lifetime: DEFAULT_IKE_LIFETIME,
             ike_port: DEFAULT_IKE_PORT,
+            client_mode: TunnelType::Ipsec.as_client_mode().to_owned(),
             config_file: Self::default_config_path(),
         }
     }

--- a/snxcore/src/tunnel/ipsec/connector.rs
+++ b/snxcore/src/tunnel/ipsec/connector.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     model::{
         params::{CertType, TunnelParams},
-        proto::{AuthenticationRealm, ClientLoggingData},
+        proto::AuthenticationRealm,
         IpsecSession, MfaChallenge, MfaType, SessionState, VpnSession,
     },
     platform,
@@ -380,14 +380,10 @@ impl TunnelConnector for IpsecTunnelConnector {
             client_type: self.params.tunnel_type.as_client_type().to_owned(),
             old_session_id: String::new(),
             protocol_version: 100,
-            client_mode: self.params.tunnel_type.as_client_mode().to_owned(),
+            client_mode: self.params.client_mode.clone(),
             selected_realm_id: self.params.login_type.clone(),
             secondary_realm_hash: None,
-            client_logging_data: Some(ClientLoggingData {
-                os_name: Some("Windows".to_owned()),
-                device_id: Some(crate::util::get_device_id().into()),
-                ..Default::default()
-            }),
+            client_logging_data: None,
         };
 
         let realm_expr = SExpression::from(&realm);


### PR DESCRIPTION
This fixes issue #33. When No MFA codes are required, proceed with IPSec session exchange directly.
