### PR TITLE
Fix: --ignore-routes not ignoring routes

### DIFF
--- a/snxcore/src/platform/linux/net.rs
+++ b/snxcore/src/platform/linux/net.rs
@@ -124,7 +124,12 @@ fn subnet_overlaps(index: usize, subnet: Ipv4Net, other: &[Ipv4Net]) -> bool {
         .any(|(i, s)| i != index && (*s == subnet || s.contains(&subnet) || subnet.contains(s)))
 }
 
-pub async fn add_routes(routes: &[Ipv4Net], device: &str, ipaddr: Ipv4Addr, ignore_routes: &[Ipv4Net]) -> anyhow::Result<()> {
+pub async fn add_routes(
+    routes: &[Ipv4Net],
+    device: &str,
+    ipaddr: Ipv4Addr,
+    ignore_routes: &[Ipv4Net],
+) -> anyhow::Result<()> {
     debug!("Routes to add: {:?}", routes);
     for (_, subnet) in routes
         .iter()
@@ -132,7 +137,7 @@ pub async fn add_routes(routes: &[Ipv4Net], device: &str, ipaddr: Ipv4Addr, igno
         .filter(|(i, s)| !subnet_overlaps(*i, **s, routes))
     {
         if ignore_routes.iter().any(|ignore| ignore.contains(subnet)) {
-            debug!("Ignoring route: {:?}", subnet);
+            debug!("Ignoring route: {}", subnet);
             continue;
         }
         let _ = add_route(*subnet, device, ipaddr).await;

--- a/snxcore/src/platform/linux/net.rs
+++ b/snxcore/src/platform/linux/net.rs
@@ -124,13 +124,17 @@ fn subnet_overlaps(index: usize, subnet: Ipv4Net, other: &[Ipv4Net]) -> bool {
         .any(|(i, s)| i != index && (*s == subnet || s.contains(&subnet) || subnet.contains(s)))
 }
 
-pub async fn add_routes(routes: &[Ipv4Net], device: &str, ipaddr: Ipv4Addr) -> anyhow::Result<()> {
+pub async fn add_routes(routes: &[Ipv4Net], device: &str, ipaddr: Ipv4Addr, ignore_routes: &[Ipv4Net]) -> anyhow::Result<()> {
     debug!("Routes to add: {:?}", routes);
     for (_, subnet) in routes
         .iter()
         .enumerate()
         .filter(|(i, s)| !subnet_overlaps(*i, **s, routes))
     {
+        if ignore_routes.iter().any(|ignore| ignore.contains(subnet)) {
+            debug!("Ignoring route: {:?}", subnet);
+            continue;
+        }
         let _ = add_route(*subnet, device, ipaddr).await;
     }
 

--- a/snxcore/src/platform/linux/xfrm.rs
+++ b/snxcore/src/platform/linux/xfrm.rs
@@ -352,10 +352,14 @@ impl XfrmConfigurator {
 
         subnets.retain(|s| !s.contains(&self.dest_ip));
 
-        let ignore_routes = self.tunnel_params.ignore_routes.clone();
-        
         if !subnets.is_empty() {
-            let _ = platform::add_routes(&subnets, &self.name, self.ipsec_session.address, &ignore_routes).await;
+            let _ = platform::add_routes(
+                &subnets,
+                &self.name,
+                self.ipsec_session.address,
+                &self.tunnel_params.ignore_routes,
+            )
+            .await;
         }
 
         let port = TunnelParams::IPSEC_KEEPALIVE_PORT.to_string();

--- a/snxcore/src/platform/linux/xfrm.rs
+++ b/snxcore/src/platform/linux/xfrm.rs
@@ -352,8 +352,10 @@ impl XfrmConfigurator {
 
         subnets.retain(|s| !s.contains(&self.dest_ip));
 
+        let ignore_routes = self.tunnel_params.ignore_routes.clone();
+        
         if !subnets.is_empty() {
-            let _ = platform::add_routes(&subnets, &self.name, self.ipsec_session.address).await;
+            let _ = platform::add_routes(&subnets, &self.name, self.ipsec_session.address, &ignore_routes).await;
         }
 
         let port = TunnelParams::IPSEC_KEEPALIVE_PORT.to_string();

--- a/snxcore/src/tunnel/ssl/device.rs
+++ b/snxcore/src/tunnel/ssl/device.rs
@@ -69,10 +69,8 @@ impl TunDevice {
 
         subnets.retain(|s| dest_ips.iter().all(|i| !s.contains(i)));
 
-        let ignore_routes = params.ignore_routes.clone();
-
         if !subnets.is_empty() {
-            let _ = platform::add_routes(&subnets, &self.dev_name, self.ipaddr, &ignore_routes).await;
+            let _ = platform::add_routes(&subnets, &self.dev_name, self.ipaddr, &params.ignore_routes).await;
         }
 
         if !params.no_dns {

--- a/snxcore/src/tunnel/ssl/device.rs
+++ b/snxcore/src/tunnel/ssl/device.rs
@@ -69,8 +69,10 @@ impl TunDevice {
 
         subnets.retain(|s| dest_ips.iter().all(|i| !s.contains(i)));
 
+        let ignore_routes = params.ignore_routes.clone();
+
         if !subnets.is_empty() {
-            let _ = platform::add_routes(&subnets, &self.dev_name, self.ipaddr).await;
+            let _ = platform::add_routes(&subnets, &self.dev_name, self.ipaddr, &ignore_routes).await;
         }
 
         if !params.no_dns {


### PR DESCRIPTION
I've noticed that --ignore-routes doesn't actually ignore routes and have attempted to implement it. Tested with IPSec tunnel.

Please let me know if this is an acceptable fix.

