### PR TITLE
Fix relative symlinks handling in resolver.rs to retrieve resolv.conf

### DIFF
--- a/snxcore/src/server.rs
+++ b/snxcore/src/server.rs
@@ -85,7 +85,7 @@ impl CommandServer {
         let req = match serde_json::from_slice::<TunnelServiceRequest>(packet) {
             Ok(req) => req,
             Err(e) => {
-                warn!("{}", e);
+                warn!("Command deserialization error: {:#}", e);
                 return TunnelServiceResponse::Error(e.to_string());
             }
         };
@@ -118,7 +118,7 @@ impl CommandServer {
                 match self.challenge_code(&code, event_sender).await {
                     Ok(()) => TunnelServiceResponse::Ok,
                     Err(e) => {
-                        warn!("{}", e);
+                        warn!("Challenge code error: {:#}", e);
                         self.reset();
                         TunnelServiceResponse::Error(e.to_string())
                     }


### PR DESCRIPTION
On Ubuntu 24.04.1, the symlink is relative:
``
$ ll /etc/resolv.conf 
``
``
lrwxrwxrwx 1 root root 39 Aug 27 17:37 /etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf
``

which on current master fails with:
``
No such file or directory (os error 2)
``

This fix resolves the relative path based on the symlink location, not cwd.

It also improves errors in this area, as finding out what file or directory was missing, considering no other context at all in logs or otherwise, was quite a challenge.