### PR TITLE
Fix `get_default_ip` for uncommon cases

### DIFF
--- a/snxcore/src/platform/linux/net.rs
+++ b/snxcore/src/platform/linux/net.rs
@@ -101,9 +101,7 @@ pub async fn get_default_ip() -> anyhow::Result<String> {
                 while let Some(part) = parts.next() {
                     if part == "inet" {
                         if let Some(ip) = parts.next() {
-                            if let Some((ip, _)) = ip.split_once('/') {
-                                return Ok(ip.to_string());
-                            }
+                            return Ok(ip.split_once('/').map_or(ip, |(before, _)| before).to_string());
                         }
                     }
                 }


### PR DESCRIPTION
On machines with `ip` command outputs something like `inet aaa.bbb.ccc.ddd` (no slash), the original version fails. Here I make it to work for those with and without a slash.

---

PS. I'm very new to Rust and some codes are generated by ChatGPT