### PR TITLE
Shell autocmpletion generation added to snx-rs, snx-rs-gui, snxctl.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +2879,7 @@ version = "4.4.4"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "futures",
  "i18n",
  "ipnet",
@@ -2889,6 +2899,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
+ "clap_complete",
  "futures",
  "gtk4",
  "hex",
@@ -2960,6 +2971,7 @@ version = "4.4.4"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "futures",
  "i18n",
  "snxcore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/ancwrd1/snx-rs"
 keywords = ["snx", "vpn", "ipsec"]
 publish = false
 
+[workspace.dependencies]
+clap_complete = { version = "4.5.*" }
+
 [profile.release]
 panic = "abort"
 

--- a/snx-rs-gui/Cargo.toml
+++ b/snx-rs-gui/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 ipnet = {  version = "2", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = { workspace = true }
 hex = "0.4"
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 futures = "0.3"

--- a/snx-rs-gui/src/main.rs
+++ b/snx-rs-gui/src/main.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, collections::HashMap, sync::Arc, time::Duration};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use gtk4::{
     Application, ApplicationWindow, License, Window,
     glib::{self, clone},
@@ -64,6 +64,17 @@ const APP_CSS: &str = include_str!("../assets/app.css");
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cmdline_params = params::CmdlineParams::parse();
+
+    // Handle completions immediately and exit
+    if let Some(shell) = cmdline_params.completions {
+        clap_complete::generate(
+            shell,
+            &mut CmdlineParams::command(),
+            "snx-rs-gui",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     let tunnel_params = Arc::new(TunnelParams::load(cmdline_params.config_file()).unwrap_or_default());
 

--- a/snx-rs-gui/src/params.rs
+++ b/snx-rs-gui/src/params.rs
@@ -20,6 +20,11 @@ pub struct CmdlineParams {
         help = "Send command to the application [connect, disconnect, settings, status, exit, about]"
     )]
     pub command: Option<TrayEvent>,
+    #[clap(
+        long = "completions",
+        help = "Generate shell completions for the given shell"
+    )]
+    pub completions: Option<clap_complete::Shell>,
 }
 
 impl CmdlineParams {

--- a/snx-rs-gui/src/params.rs
+++ b/snx-rs-gui/src/params.rs
@@ -20,10 +20,7 @@ pub struct CmdlineParams {
         help = "Send command to the application [connect, disconnect, settings, status, exit, about]"
     )]
     pub command: Option<TrayEvent>,
-    #[clap(
-        long = "completions",
-        help = "Generate shell completions for the given shell"
-    )]
+    #[clap(long = "completions", help = "Generate shell completions for the given shell")]
     pub completions: Option<clap_complete::Shell>,
 }
 

--- a/snx-rs/Cargo.toml
+++ b/snx-rs/Cargo.toml
@@ -20,4 +20,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 libc = "0.2"
 tracing-subscriber = "0.3"
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = { workspace = true }
 ipnet = {  version = "2", features = ["serde"] }

--- a/snx-rs/src/cmdline.rs
+++ b/snx-rs/src/cmdline.rs
@@ -195,10 +195,7 @@ pub struct CmdlineParams {
         help = "Enable port knock workaround for NAT-T probing"
     )]
     pub port_knock: Option<bool>,
-    #[clap(
-        long = "completions",
-        help = "Generate shell completions for the given shell"
-    )]
+    #[clap(long = "completions", help = "Generate shell completions for the given shell")]
     pub completions: Option<clap_complete::Shell>,
 }
 

--- a/snx-rs/src/cmdline.rs
+++ b/snx-rs/src/cmdline.rs
@@ -195,6 +195,11 @@ pub struct CmdlineParams {
         help = "Enable port knock workaround for NAT-T probing"
     )]
     pub port_knock: Option<bool>,
+    #[clap(
+        long = "completions",
+        help = "Generate shell completions for the given shell"
+    )]
+    pub completions: Option<clap_complete::Shell>,
 }
 
 impl CmdlineParams {

--- a/snx-rs/src/main.rs
+++ b/snx-rs/src/main.rs
@@ -62,12 +62,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Handle completions immediately and exit
     if let Some(shell) = cmdline_params.completions {
-        clap_complete::generate(
-            shell,
-            &mut CmdlineParams::command(),
-            "snx-rs",
-            &mut std::io::stdout(),
-        );
+        clap_complete::generate(shell, &mut CmdlineParams::command(), "snx-rs", &mut std::io::stdout());
         return Ok(());
     }
 

--- a/snx-rs/src/main.rs
+++ b/snx-rs/src/main.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, sync::Arc};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use futures::pin_mut;
 use i18n::tr;
 use snxcore::{
@@ -59,6 +59,17 @@ where
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cmdline_params = CmdlineParams::parse();
+
+    // Handle completions immediately and exit
+    if let Some(shell) = cmdline_params.completions {
+        clap_complete::generate(
+            shell,
+            &mut CmdlineParams::command(),
+            "snx-rs",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if cmdline_params.mode != OperationMode::Info && !is_root() {
         anyhow::bail!(tr!("error-no-root-privileges"));

--- a/snxctl/Cargo.toml
+++ b/snxctl/Cargo.toml
@@ -18,4 +18,5 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = { workspace = true }
 futures = "0.3"

--- a/snxctl/src/main.rs
+++ b/snxctl/src/main.rs
@@ -39,9 +39,12 @@ enum SnxCommand {
     Info,
     #[clap(name = "completions", about = "Generate shell completions")]
     Completions {
-        #[clap(default_value="bash", help = "The shell to generate completions for (bash, elvish, fish, zsh))")]
+        #[clap(
+            default_value = "bash",
+            help = "The shell to generate completions for (bash, elvish, fish, zsh))"
+        )]
         shell: clap_complete::Shell,
-    }
+    },
 }
 
 impl From<SnxCommand> for ServiceCommand {


### PR DESCRIPTION
Added support for shell autocompletion generation via --completions flag or completions subcommand. Supports bash, elvish, fish and zsh.