### PR TITLE
Make default_authentication_method optional

### DIFF
--- a/crates/snxcore/src/model/proto.rs
+++ b/crates/snxcore/src/model/proto.rs
@@ -275,7 +275,7 @@ pub struct ProtocolVersion {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConnectivityInfo {
-    pub default_authentication_method: String,
+    pub default_authentication_method: Option<String>,
     pub client_enabled: bool,
     pub supported_data_tunnel_protocols: Vec<String>,
     pub connectivity_type: String,


### PR DESCRIPTION
Some servers don't send this field, thus making deserialization fail, which we can overcome by making it optional.