### PR TITLE
Disable by default DNSOverTLS on the VPN link

### DIFF
--- a/crates/snxcore/src/platform/linux/resolver.rs
+++ b/crates/snxcore/src/platform/linux/resolver.rs
@@ -37,6 +37,7 @@ impl ResolverConfigurator for SystemdResolvedConfigurator {
         let _ = crate::util::run_command("resolvectl", ["default-route", &self.device, "false"]).await;
         let _ = crate::util::run_command("resolvectl", ["mdns", &self.device, "false"]).await;
         let _ = crate::util::run_command("resolvectl", ["llmnr", &self.device, "false"]).await;
+        let _ = crate::util::run_command("resolvectl", ["dnsovertls", &self.device, "false"]).await;
 
         let mut args = vec!["dns".to_owned(), self.device.clone()];
 


### PR DESCRIPTION
Disable by default DNSOverTLS on the VPN link, some distributions have DNSOverTLS enabled globally.
Because this VPN link is not managed by NetworkManager or systemd-networkd there's no configuration file where to change this on a per-link basis.

The DNS traffic is encrypted by the VPN anyway so there's no need to have this as an option.

Before:
```
Link 8 (snx-xfrm)
    Current Scopes: DNS
         Protocols: -DefaultRoute -LLMNR -mDNS +DNSOverTLS DNSSEC=no/unsupported
Current DNS Server: 172.16.230.53
       DNS Servers: 172.16.230.53 172.16.230.54
        DNS Domain: dev.local prod.local
     Default Route: no
```

After:
```
Link 8 (snx-xfrm)
    Current Scopes: DNS
         Protocols: -DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported
Current DNS Server: 172.16.230.53
       DNS Servers: 172.16.230.53 172.16.230.54
        DNS Domain: dev.local prod.local
     Default Route: no
```