### PR TITLE
Add routes even when routing is disabled

### DIFF
--- a/crates/snxcore/src/tunnel/ipsec/imp/native.rs
+++ b/crates/snxcore/src/tunnel/ipsec/imp/native.rs
@@ -141,7 +141,7 @@ impl NativeIPsecTunnel {
         let config = if self.params.no_routing {
             RoutingConfig::Split {
                 destination: self.gateway_address,
-                routes: Vec::new(),
+                routes: self.params.add_routes.clone(),
             }
         } else if self.params.default_route {
             RoutingConfig::Full {

--- a/crates/snxcore/src/tunnel/ipsec/imp/tun.rs
+++ b/crates/snxcore/src/tunnel/ipsec/imp/tun.rs
@@ -151,7 +151,7 @@ impl TunIPsecTunnel {
         let config = if self.params.no_routing {
             RoutingConfig::Split {
                 destination: self.gateway_address,
-                routes: Vec::new(),
+                routes: self.params.add_routes.clone(),
             }
         } else if self.params.default_route {
             RoutingConfig::Full {

--- a/crates/snxcore/src/tunnel/ssl.rs
+++ b/crates/snxcore/src/tunnel/ssl.rs
@@ -247,11 +247,9 @@ impl SslTunnel {
             server_info::get(&self.params).await?.connectivity_info.tcpt_port,
         )?;
 
-        if self.params.no_routing {
-            return Ok(());
-        }
-
-        let config = if self.params.default_route {
+        let config = if self.params.no_routing {
+            RoutingConfig::Split { destination: dest_ip, routes: self.params.add_routes.clone() }
+        } else if self.params.default_route {
             RoutingConfig::Full {
                 destination: dest_ip,
                 disable_ipv6: self.params.disable_ipv6,

--- a/crates/snxcore/src/tunnel/ssl.rs
+++ b/crates/snxcore/src/tunnel/ssl.rs
@@ -248,7 +248,10 @@ impl SslTunnel {
         )?;
 
         let config = if self.params.no_routing {
-            RoutingConfig::Split { destination: dest_ip, routes: self.params.add_routes.clone() }
+            RoutingConfig::Split {
+                destination: dest_ip,
+                routes: self.params.add_routes.clone(),
+            }
         } else if self.params.default_route {
             RoutingConfig::Full {
                 destination: dest_ip,


### PR DESCRIPTION
This feels like an oversight. 

When routing is disabled, keep-alive automatically fails, and no routes can be added. This is required in my case, as some VPNs mess up your routing table by adding just about 200 routes to the routing table. When these eventually overlap, the overlapping ones get silently removed by the kernel.

You can remove all routes manually by adding them to ignored routes, and add only the routes you want. The workaround is fine, but this solution feels more elegant.

Pushing the network address with custom specified routes to add could also be done.

In short, I don't think no routing should functionally render the VPN broken.