### PR TITLE
Fix the nmcheck error on limited corporate networks

### DIFF
--- a/crates/snxcore/src/platform/linux/net.rs
+++ b/crates/snxcore/src/platform/linux/net.rs
@@ -76,7 +76,7 @@ impl From<u32> for NetworkManagerState {
 
 impl NetworkManagerState {
     fn is_online(self) -> bool {
-        matches!(self, Self::ConnectedGlobal)
+        matches!(self, Self::ConnectedSite | Self::ConnectedGlobal)
     }
 }
 


### PR DESCRIPTION
So the issue looked like this at first: connecting to the corporate VPN from home or by a mobile hotspot was totally fine - the tunnel happily up all day. But if I connect over office wifi the headaches kicked in. Every 15 minutes the tunnel would die and I have to reconnect. I tried every config combos I could think of. Different tunnel-types, tcp, tls, etc and none of it helped.
Turned out the answer was way simpler than I thought.

On a healthy network `nmcli general status` should look like this:

```
STATE      CONNECTIVITY  WIFI-HW  WIFI     WWAN-HW  WWAN     METERED
connected  full          enabled  enabled  missing  enabled  no (guessed)
```

But on some corporate networks `nmcheck` is limited and you end up with this instead:

```
STATE                  CONNECTIVITY  WIFI-HW  WIFI     WWAN-HW  WWAN     METERED
connected (site only)  limited       enabled  enabled  missing  enabled  no (guessed)
```

So that the `is_online` check never gets satisfied. NetworkManager never flips its state over to `ConnectedGlobal`. The next rekey request never fires. And the tunnel quietly dies the moment the current SA times out - 15 minutes in my case.
