### PR TITLE
Add experimental macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,30 @@ jobs:
         channel: [stable]
         target:
           - x86_64-pc-windows-msvc
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Install Rust compiler
+        run: |
+          rustup update
+          rustup default ${{ matrix.channel }}
+          rustup target add ${{ matrix.target }}
+          rustup component add clippy rustfmt
+      - name: Formatting checks
+        run: cargo fmt --check
+      - name: Clippy checks
+        run: cargo clippy --target ${{ matrix.target }} -p snxcore -p snx-rs -p snxctl --features snxcore/vendored-openssl -- -D warnings
+      - name: Tests
+        run: cargo test --target ${{ matrix.target }} -p snxcore -p snx-rs -p snxctl --features snxcore/vendored-openssl
+
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable]
+        target:
+          - aarch64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v6.2.0 (TBD)
+This version adds experimental support to run snx-rs on macOS, on both Apple Silicon and Intel.
+Networking is implemented using native macOS APIs (utun, PF_ROUTE routing sockets, SystemConfiguration, Keychain) instead of shelling out to external tools, the same approach used on Linux and Windows.
+Build from source, no packaged installer or signed binaries yet.
+
+- IPsec uses a userspace TUN/ESP transport, same as on Windows, since macOS has no kernel xfrm module.
+- Split DNS is implemented via SystemConfiguration (SCDynamicStore) scoped/supplemental match domains.
+- CLI only for now; the `snx-rs-gui` frontend is not ported to macOS.
+
 ## v6.1.2 (2026-06-25)
 - Fixed a problem with connectivity check on some corporate networks
 - Fixed a bug in the UI where the XFRM transport choice was not shown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6541,9 +6541,11 @@ dependencies = [
  "rusqlite",
  "secrecy",
  "secret-service",
+ "security-framework",
  "serde",
  "serde_json",
  "sysctl",
+ "system-configuration",
  "tempfile",
  "tokio",
  "tokio-native-tls",
@@ -6804,6 +6806,27 @@ dependencies = [
  "libc",
  "thiserror 2.0.18",
  "walkdir",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://img.shields.io/badge/License-AGPL-v3.svg)](https://opensource.org/license/agpl-v3)
 
 This project contains the source code for an unofficial client for Check Point VPN, written in Rust.
-Currently supported platforms: Linux, Windows.
+Currently supported platforms: Linux, Windows, macOS.
 
 ## Key Features
 

--- a/crates/snxcore/Cargo.toml
+++ b/crates/snxcore/Cargo.toml
@@ -64,6 +64,11 @@ xfrmnetlink = "0.3"
 netlink-packet-xfrm = "0.4"
 nix = { version = "0.31", features = ["fs", "user", "socket"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+nix = { version = "0.31", features = ["user", "socket", "net", "fs"] }
+system-configuration = "0.7"
+security-framework = "3"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/crates/snxcore/src/platform.rs
+++ b/crates/snxcore/src/platform.rs
@@ -12,6 +12,8 @@ use async_trait::async_trait;
 use ipnet::Ipv4Net;
 #[cfg(target_os = "linux")]
 use linux::LinuxPlatformAccess as PlatformAccessImpl;
+#[cfg(target_os = "macos")]
+use macos::MacosPlatformAccess as PlatformAccessImpl;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
@@ -26,6 +28,8 @@ use crate::model::{
 
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
 #[cfg(target_os = "windows")]
 mod windows;
 

--- a/crates/snxcore/src/platform/macos.rs
+++ b/crates/snxcore/src/platform/macos.rs
@@ -1,0 +1,114 @@
+#![allow(unsafe_code)]
+
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    path::PathBuf,
+    time::Duration,
+};
+
+use tokio::net::UdpSocket;
+use uuid::Uuid;
+
+use crate::{
+    model::{IPsecSession, params::TunnelType},
+    platform::{
+        DeviceConfig, IPsecConfigurator, Keychain, NetworkInterface, PlatformAccess, PlatformFeatures,
+        ResolverConfigurator, RoutingConfigurator, SingleInstance, UdpEncapType, UdpSocketExt,
+    },
+};
+
+mod ipsec_stub;
+mod keychain;
+mod machine_uuid;
+mod net;
+mod resolver;
+mod routing;
+mod single_instance;
+mod stats;
+
+// macOS has no in-kernel ESP-in-UDP encapsulation; the userspace ESP data path
+// (forced by ipsec_native = false) drives the raw socket itself, so these are no-ops.
+impl UdpSocketExt for UdpSocket {
+    fn set_encapsulation(&self, _encap: UdpEncapType) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn set_no_check(&self, _flag: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn bind_to_tunnel(&self, _device: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn send_receive(&self, data: &[u8], timeout: Duration, target: SocketAddr) -> anyhow::Result<Vec<u8>> {
+        super::udp_send_receive(self, data, timeout, target).await
+    }
+}
+
+pub struct MacosPlatformAccess;
+
+impl PlatformAccess for MacosPlatformAccess {
+    async fn get_features(&self) -> PlatformFeatures {
+        PlatformFeatures {
+            ipsec_native: false,
+            // The tunnel stays up without an app-level keepalive, so leave it off.
+            ipsec_keepalive: false,
+            split_dns: true,
+        }
+    }
+
+    fn new_resolver_configurator<S: AsRef<str>>(
+        &self,
+        device: S,
+    ) -> anyhow::Result<Box<dyn ResolverConfigurator + Send + Sync>> {
+        resolver::new_resolver_configurator(device)
+    }
+
+    fn new_keychain(&self) -> impl Keychain + Send + Sync {
+        keychain::MacosKeychain::new()
+    }
+
+    fn get_machine_uuid(&self) -> anyhow::Result<Uuid> {
+        machine_uuid::get_machine_uuid()
+    }
+
+    fn is_root(&self) -> bool {
+        nix::unistd::Uid::effective().is_root()
+    }
+
+    fn init(&self) {}
+
+    fn new_ipsec_configurator(
+        &self,
+        device_config: DeviceConfig,
+        ipsec_session: IPsecSession,
+        src_ip: Ipv4Addr,
+        src_port: u16,
+        dest_ip: Ipv4Addr,
+        dest_port: u16,
+    ) -> impl IPsecConfigurator + use<> + Send + Sync {
+        ipsec_stub::MacosIPsecStub::new(device_config, ipsec_session, src_ip, src_port, dest_ip, dest_port)
+    }
+
+    async fn new_routing_configurator<S: AsRef<str> + Send>(
+        &self,
+        device: S,
+        tunnel_type: TunnelType,
+    ) -> anyhow::Result<Box<dyn RoutingConfigurator + Send + Sync>> {
+        Ok(Box::new(routing::MacosRoutingConfigurator::new(device, tunnel_type)))
+    }
+
+    fn new_network_interface(&self) -> impl NetworkInterface + Send + Sync + 'static {
+        net::MacosNetworkInterface::new()
+    }
+
+    fn new_single_instance<S: AsRef<str>>(&self, name: S) -> anyhow::Result<impl SingleInstance + 'static> {
+        single_instance::MacosSingleInstance::new(name)
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+        PathBuf::from(home).join("Library/Application Support/snx-rs")
+    }
+}

--- a/crates/snxcore/src/platform/macos/ipsec_stub.rs
+++ b/crates/snxcore/src/platform/macos/ipsec_stub.rs
@@ -1,0 +1,51 @@
+use std::net::Ipv4Addr;
+
+use async_trait::async_trait;
+
+use crate::{
+    model::IPsecSession,
+    platform::{DeviceConfig, IPsecConfigurator},
+};
+
+pub struct MacosIPsecStub {
+    _device_config: DeviceConfig,
+    _ipsec_session: IPsecSession,
+    _src_ip: Ipv4Addr,
+    _src_port: u16,
+    _dest_ip: Ipv4Addr,
+    _dest_port: u16,
+}
+
+impl MacosIPsecStub {
+    pub fn new(
+        device_config: DeviceConfig,
+        ipsec_session: IPsecSession,
+        src_ip: Ipv4Addr,
+        src_port: u16,
+        dest_ip: Ipv4Addr,
+        dest_port: u16,
+    ) -> Self {
+        Self {
+            _device_config: device_config,
+            _ipsec_session: ipsec_session,
+            _src_ip: src_ip,
+            _src_port: src_port,
+            _dest_ip: dest_ip,
+            _dest_port: dest_port,
+        }
+    }
+}
+
+// Userspace ESP (ipsec_native = false) handles the data path, so there is no kernel SA to configure.
+#[async_trait]
+impl IPsecConfigurator for MacosIPsecStub {
+    async fn configure(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn rekey(&mut self, _session: &IPsecSession) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn cleanup(&self) {}
+}

--- a/crates/snxcore/src/platform/macos/keychain.rs
+++ b/crates/snxcore/src/platform/macos/keychain.rs
@@ -1,0 +1,45 @@
+use secrecy::{ExposeSecret, SecretString};
+use security_framework::passwords::{delete_generic_password, get_generic_password, set_generic_password};
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::platform::Keychain;
+
+const SERVICE: &str = "snx-rs";
+
+// Security/SecBase.h errSecItemNotFound: SecItemDelete returns it when the entry is already gone.
+const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+#[derive(Default)]
+pub struct MacosKeychain;
+
+impl MacosKeychain {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Keychain for MacosKeychain {
+    async fn acquire_password(&self, profile_id: Uuid) -> anyhow::Result<String> {
+        debug!("Reading password from the keychain for profile {profile_id}");
+        // The daemon runs as root, where the login keychain is out of reach: the lookup fails with
+        // errSecInteractionNotAllowed instead of returning data. Propagate it so the caller prompts.
+        let bytes = get_generic_password(SERVICE, &profile_id.to_string())?;
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    async fn store_password(&self, profile_id: Uuid, password: &SecretString) -> anyhow::Result<()> {
+        debug!("Storing password in the keychain for profile {profile_id}");
+        set_generic_password(SERVICE, &profile_id.to_string(), password.expose_secret().as_bytes())?;
+        Ok(())
+    }
+
+    async fn delete_password(&self, profile_id: Uuid) -> anyhow::Result<()> {
+        debug!("Deleting password from the keychain for profile {profile_id}");
+        match delete_generic_password(SERVICE, &profile_id.to_string()) {
+            Ok(()) => Ok(()),
+            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/crates/snxcore/src/platform/macos/machine_uuid.rs
+++ b/crates/snxcore/src/platform/macos/machine_uuid.rs
@@ -1,0 +1,15 @@
+use cached::cached;
+use tracing::warn;
+use uuid::Uuid;
+
+#[cached]
+pub fn get_machine_uuid() -> anyhow::Result<Uuid> {
+    let mut bytes = [0u8; 16];
+    let timeout = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+    let rc = unsafe { libc::gethostuuid(bytes.as_mut_ptr(), &timeout) };
+    if rc != 0 {
+        warn!("gethostuuid failed, falling back to nil UUID");
+        return Ok(Uuid::nil());
+    }
+    Ok(Uuid::from_bytes(bytes))
+}

--- a/crates/snxcore/src/platform/macos/net.rs
+++ b/crates/snxcore/src/platform/macos/net.rs
@@ -1,0 +1,480 @@
+use std::{
+    ffi::CStr,
+    mem,
+    net::{Ipv4Addr, Ipv6Addr},
+    os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd},
+    ptr,
+    sync::atomic::{AtomicI32, Ordering},
+};
+
+use anyhow::anyhow;
+use ipnet::Ipv4Net;
+use libc::{c_char, c_int, c_ulong, c_void};
+use nix::sys::{
+    socket::{AddressFamily, SockFlag, SockType, setsockopt, socket, sockopt::ReceiveTimeout},
+    time::TimeVal,
+};
+use tracing::debug;
+
+use crate::platform::{DeviceConfig, NetworkInterface, StatsPoller};
+
+// BSD `_IOW('i', n, T)` request encoding; sizeof(T) is baked into the request number, so the
+// struct we hand to `ioctl` must be exactly that size (see the InAliasReq / libc::ifreq notes).
+const fn iow(group: u8, num: u8, len: usize) -> c_ulong {
+    const IOC_IN: c_ulong = 0x8000_0000;
+    const IOCPARM_MASK: c_ulong = 0x1fff;
+    IOC_IN | (((len as c_ulong) & IOCPARM_MASK) << 16) | ((group as c_ulong) << 8) | num as c_ulong
+}
+
+const SIOCSIFMTU: c_ulong = iow(b'i', 52, mem::size_of::<libc::ifreq>());
+const SIOCAIFADDR: c_ulong = iow(b'i', 26, mem::size_of::<InAliasReq>());
+const SIOCDIFADDR: c_ulong = iow(b'i', 25, mem::size_of::<libc::ifreq>());
+
+// netinet/in_var.h: same 64-byte layout as `struct ifaliasreq` but with sockaddr_in members.
+#[repr(C)]
+struct InAliasReq {
+    ifra_name: [c_char; libc::IFNAMSIZ],
+    ifra_addr: libc::sockaddr_in,
+    ifra_dstaddr: libc::sockaddr_in,
+    ifra_mask: libc::sockaddr_in,
+}
+
+static ROUTE_SEQ: AtomicI32 = AtomicI32::new(1);
+
+pub(super) fn next_seq() -> c_int {
+    ROUTE_SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(super) fn struct_bytes<T>(v: &T) -> &[u8] {
+    unsafe { std::slice::from_raw_parts((v as *const T).cast::<u8>(), mem::size_of::<T>()) }
+}
+
+pub(super) fn sockaddr_in(addr: Ipv4Addr) -> libc::sockaddr_in {
+    libc::sockaddr_in {
+        sin_len: mem::size_of::<libc::sockaddr_in>() as u8,
+        sin_family: libc::AF_INET as libc::sa_family_t,
+        sin_port: 0,
+        sin_addr: libc::in_addr {
+            s_addr: u32::from_ne_bytes(addr.octets()),
+        },
+        sin_zero: [0; 8],
+    }
+}
+
+pub(super) fn sockaddr_in6(addr: Ipv6Addr) -> libc::sockaddr_in6 {
+    libc::sockaddr_in6 {
+        sin6_len: mem::size_of::<libc::sockaddr_in6>() as u8,
+        sin6_family: libc::AF_INET6 as libc::sa_family_t,
+        sin6_port: 0,
+        sin6_flowinfo: 0,
+        sin6_addr: libc::in6_addr { s6_addr: addr.octets() },
+        sin6_scope_id: 0,
+    }
+}
+
+pub(super) fn sockaddr_dl(ifindex: u16) -> libc::sockaddr_dl {
+    let mut sdl: libc::sockaddr_dl = unsafe { mem::zeroed() };
+    sdl.sdl_len = mem::size_of::<libc::sockaddr_dl>() as u8;
+    sdl.sdl_family = libc::AF_LINK as u8;
+    sdl.sdl_index = ifindex;
+    sdl
+}
+
+pub(super) fn route_socket() -> anyhow::Result<OwnedFd> {
+    let fd = socket(AddressFamily::Route, SockType::Raw, SockFlag::empty(), None)?;
+    // route_get() reads synchronously from async keepalive/scv loops; bound the wait so a lost
+    // or never-matching reply cannot hang a Tokio worker indefinitely.
+    setsockopt(&fd, ReceiveTimeout, &TimeVal::new(2, 0))?;
+    Ok(fd)
+}
+
+fn inet_dgram_socket() -> anyhow::Result<OwnedFd> {
+    Ok(socket(
+        AddressFamily::Inet,
+        SockType::Datagram,
+        SockFlag::empty(),
+        None,
+    )?)
+}
+
+// PF_ROUTE sockaddrs are padded to a 4-byte boundary; a zero-length sockaddr still advances one word.
+fn roundup(len: usize) -> usize {
+    let word = mem::size_of::<u32>();
+    if len == 0 { word } else { (len + word - 1) & !(word - 1) }
+}
+
+// `parts` must be supplied in ascending RTA_* bit order.
+pub(super) fn build_route_message(rtm_type: u8, rtm_flags: c_int, rtm_seq: c_int, parts: &[(c_int, &[u8])]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    let mut rtm_addrs = 0;
+    for (bit, sa) in parts {
+        rtm_addrs |= *bit;
+        let start = payload.len();
+        payload.extend_from_slice(sa);
+        payload.resize(start + roundup(sa.len()), 0);
+    }
+
+    let total = mem::size_of::<libc::rt_msghdr>() + payload.len();
+    let mut hdr: libc::rt_msghdr = unsafe { mem::zeroed() };
+    hdr.rtm_msglen = total as u16;
+    hdr.rtm_version = libc::RTM_VERSION as u8;
+    hdr.rtm_type = rtm_type;
+    hdr.rtm_flags = rtm_flags;
+    hdr.rtm_addrs = rtm_addrs;
+    hdr.rtm_seq = rtm_seq;
+
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(struct_bytes(&hdr));
+    buf.extend_from_slice(&payload);
+    buf
+}
+
+pub(super) fn send_route_message(fd: BorrowedFd<'_>, buf: &[u8]) -> std::io::Result<()> {
+    nix::unistd::write(fd, buf).map_err(std::io::Error::from)?;
+    Ok(())
+}
+
+pub(super) struct RouteReply {
+    pub ifindex: u16,
+    pub gateway: Option<Vec<u8>>,
+}
+
+pub(super) fn route_get(fd: BorrowedFd<'_>, dst: Ipv4Addr) -> anyhow::Result<RouteReply> {
+    let seq = next_seq();
+    let dst_sa = sockaddr_in(dst);
+    let msg = build_route_message(libc::RTM_GET as u8, 0, seq, &[(libc::RTA_DST, struct_bytes(&dst_sa))]);
+    send_route_message(fd, &msg)?;
+
+    let pid = unsafe { libc::getpid() };
+    let mut buf = [0u8; 2048];
+    loop {
+        // A receive timeout (set in route_socket) surfaces here as EAGAIN and is propagated.
+        let n = nix::unistd::read(fd, &mut buf).map_err(std::io::Error::from)?;
+        if n < mem::size_of::<libc::rt_msghdr>() {
+            continue;
+        }
+        let hdr: libc::rt_msghdr = unsafe { std::ptr::read_unaligned(buf.as_ptr().cast()) };
+        if hdr.rtm_type as c_int != libc::RTM_GET || hdr.rtm_seq != seq || hdr.rtm_pid != pid {
+            continue;
+        }
+
+        let mut offset = mem::size_of::<libc::rt_msghdr>();
+        let mut gateway = None;
+        for i in 0..libc::RTAX_MAX {
+            if hdr.rtm_addrs & (1 << i) == 0 || offset >= n {
+                continue;
+            }
+            let sa_len = buf[offset] as usize;
+            if i == libc::RTAX_GATEWAY && sa_len != 0 {
+                gateway = Some(buf[offset..(offset + sa_len).min(n)].to_vec());
+            }
+            offset += roundup(sa_len);
+        }
+
+        return Ok(RouteReply {
+            ifindex: hdr.rtm_index,
+            gateway,
+        });
+    }
+}
+
+fn copy_ifname(dst: &mut [c_char; libc::IFNAMSIZ], name: &str) {
+    let bytes = name.as_bytes();
+    let n = bytes.len().min(dst.len() - 1);
+    for (slot, byte) in dst.iter_mut().zip(&bytes[..n]) {
+        *slot = *byte as c_char;
+    }
+}
+
+fn ioctl<T>(fd: BorrowedFd<'_>, request: c_ulong, arg: &T) -> std::io::Result<()> {
+    let rc = unsafe { libc::ioctl(fd.as_raw_fd(), request, arg as *const T) };
+    if rc < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn set_mtu(fd: BorrowedFd<'_>, name: &str, mtu: u16) -> std::io::Result<()> {
+    let mut req: libc::ifreq = unsafe { mem::zeroed() };
+    copy_ifname(&mut req.ifr_name, name);
+    req.ifr_ifru.ifru_mtu = mtu as c_int;
+    ioctl(fd, SIOCSIFMTU, &req)
+}
+
+fn add_alias(fd: BorrowedFd<'_>, name: &str, net: Ipv4Net) -> std::io::Result<()> {
+    let mut req: InAliasReq = unsafe { mem::zeroed() };
+    copy_ifname(&mut req.ifra_name, name);
+    req.ifra_addr = sockaddr_in(net.addr());
+    // utun is point-to-point; set the peer address to the interface address itself.
+    req.ifra_dstaddr = sockaddr_in(net.addr());
+    req.ifra_mask = sockaddr_in(net.netmask());
+    ioctl(fd, SIOCAIFADDR, &req)
+}
+
+fn del_address(fd: BorrowedFd<'_>, name: &str, addr: Ipv4Addr) -> std::io::Result<()> {
+    let mut req: libc::ifreq = unsafe { mem::zeroed() };
+    copy_ifname(&mut req.ifr_name, name);
+    let sin = sockaddr_in(addr);
+    req.ifr_ifru.ifru_addr = unsafe { mem::transmute_copy(&sin) };
+    match ioctl(fd, SIOCDIFADDR, &req) {
+        Err(e) if e.raw_os_error() == Some(libc::EADDRNOTAVAIL) => Ok(()),
+        other => other,
+    }
+}
+
+fn if_indextoname(index: u16) -> Option<String> {
+    let mut buf = [0 as c_char; libc::IF_NAMESIZE];
+    let ret = unsafe { libc::if_indextoname(index as libc::c_uint, buf.as_mut_ptr()) };
+    if ret.is_null() {
+        return None;
+    }
+    Some(unsafe { CStr::from_ptr(buf.as_ptr()) }.to_string_lossy().into_owned())
+}
+
+fn is_point_to_point(name: &str) -> bool {
+    nix::ifaddrs::getifaddrs().is_ok_and(|addrs| {
+        addrs
+            .filter(|ifa| ifa.interface_name == name)
+            .any(|ifa| ifa.flags.contains(nix::net::if_::InterfaceFlags::IFF_POINTOPOINT))
+    })
+}
+
+// sysctl(CTL_NET, PF_ROUTE, 0, AF_INET, NET_RT_DUMP, 0) returns the whole IPv4 routing table as a
+// sequence of rt_msghdr-prefixed messages, each padded to rtm_msglen.
+fn dump_inet_routes() -> anyhow::Result<Vec<u8>> {
+    let mut mib = [libc::CTL_NET, libc::PF_ROUTE, 0, libc::AF_INET, libc::NET_RT_DUMP, 0];
+    let mut needed: libc::size_t = 0;
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            ptr::null_mut(),
+            &mut needed,
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut buf = vec![0u8; needed];
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            buf.as_mut_ptr().cast(),
+            &mut needed,
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    buf.truncate(needed);
+    Ok(buf)
+}
+
+// Number of set bits in a routing-socket netmask sockaddr. These sockaddrs are truncated to their
+// significant bytes (sa_len), so a missing tail counts as zero and a /0 default reports sa_len 0.
+fn netmask_prefix_len(sa: &[u8]) -> u32 {
+    // sockaddr_in holds sin_addr at bytes 4..8
+    sa.get(4..8.min(sa.len()))
+        .map_or(0, |b| b.iter().map(|x| x.count_ones()).sum())
+}
+
+fn route_is_default(body: &[u8], rtm_addrs: c_int) -> bool {
+    let mut offset = 0;
+    let mut have_dst = false;
+    let mut dst_zero = false;
+    let mut netmask_zero = true;
+    for i in 0..libc::RTAX_MAX {
+        if rtm_addrs & (1 << i) == 0 {
+            continue;
+        }
+        if offset >= body.len() {
+            break;
+        }
+        let sa_len = body[offset] as usize;
+        let sa = &body[offset..(offset + sa_len).min(body.len())];
+        if i == libc::RTAX_DST {
+            have_dst = true;
+            dst_zero = sa.get(4..8).is_none_or(|b| b.iter().all(|&x| x == 0));
+        } else if i == libc::RTAX_NETMASK {
+            netmask_zero = netmask_prefix_len(sa) == 0;
+        }
+        offset += roundup(sa_len);
+    }
+    have_dst && dst_zero && netmask_zero
+}
+
+// RTM_GET cannot be used here: it does longest-prefix match, so a covering half-default (e.g. a
+// VPN's 0.0.0.0/1) would shadow the real default and bind us to a tunnel's source address.
+// Enumerate the table and pick the /0 gateway route on a non-point-to-point interface instead.
+fn default_route_interface() -> anyhow::Result<String> {
+    let buf = dump_inet_routes()?;
+    let hdr_len = mem::size_of::<libc::rt_msghdr>();
+    let mut offset = 0;
+    while offset + hdr_len <= buf.len() {
+        let hdr: libc::rt_msghdr = unsafe { ptr::read_unaligned(buf[offset..].as_ptr().cast()) };
+        let msglen = hdr.rtm_msglen as usize;
+        if msglen < hdr_len || offset + msglen > buf.len() {
+            break;
+        }
+
+        let is_default = hdr.rtm_flags & libc::RTF_UP != 0
+            && hdr.rtm_flags & libc::RTF_GATEWAY != 0
+            && route_is_default(&buf[offset + hdr_len..offset + msglen], hdr.rtm_addrs);
+
+        if is_default
+            && let Some(name) = if_indextoname(hdr.rtm_index)
+            && !is_point_to_point(&name)
+        {
+            return Ok(name);
+        }
+
+        offset += msglen;
+    }
+
+    Err(anyhow!(i18n::tr!("error-cannot-determine-ip")))
+}
+
+// Previous value of net.inet.ip.forwarding captured before we enabled it, or -1 if untouched.
+static SAVED_IP_FORWARDING: AtomicI32 = AtomicI32::new(-1);
+
+const IP_FORWARDING_CTL: &CStr = c"net.inet.ip.forwarding";
+
+fn get_ip_forwarding() -> std::io::Result<c_int> {
+    let mut value: c_int = 0;
+    let mut size = mem::size_of::<c_int>();
+    let rc = unsafe {
+        libc::sysctlbyname(
+            IP_FORWARDING_CTL.as_ptr(),
+            (&mut value as *mut c_int).cast::<c_void>(),
+            &mut size,
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(value)
+}
+
+fn set_ip_forwarding(value: c_int) -> std::io::Result<()> {
+    let mut value = value;
+    let rc = unsafe {
+        libc::sysctlbyname(
+            IP_FORWARDING_CTL.as_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            (&mut value as *mut c_int).cast::<c_void>(),
+            mem::size_of::<c_int>(),
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+pub struct MacosNetworkInterface;
+
+impl MacosNetworkInterface {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl NetworkInterface for MacosNetworkInterface {
+    async fn start_network_state_monitoring(&self) -> anyhow::Result<()> {
+        // is_online() probes the routing table on demand, so no background watcher is needed.
+        Ok(())
+    }
+
+    async fn get_default_ipv4(&self) -> anyhow::Result<Ipv4Addr> {
+        let name = default_route_interface()?;
+
+        for ifa in nix::ifaddrs::getifaddrs()? {
+            if ifa.interface_name == name
+                && let Some(ip) = ifa.address.and_then(|a| a.as_sockaddr_in().map(|s| s.ip()))
+            {
+                debug!("Default route via {name} with address {ip}");
+                return Ok(ip);
+            }
+        }
+
+        Err(anyhow!(i18n::tr!("error-cannot-determine-ip")))
+    }
+
+    async fn delete_device(&self, _device_name: &str) -> anyhow::Result<()> {
+        // Restore the global IP forwarding value if configure_device changed it.
+        let saved = SAVED_IP_FORWARDING.swap(-1, Ordering::SeqCst);
+        if saved >= 0
+            && let Err(e) = set_ip_forwarding(saved)
+        {
+            debug!("Failed to restore net.inet.ip.forwarding: {e}");
+        }
+        // utun disappears when the tun fd is dropped
+        Ok(())
+    }
+
+    async fn configure_device(&self, device_config: &DeviceConfig) -> anyhow::Result<()> {
+        debug!("Configuring device: {:?}", device_config);
+        let sock = inet_dgram_socket()?;
+        set_mtu(sock.as_fd(), &device_config.name, device_config.mtu)?;
+        add_alias(sock.as_fd(), &device_config.name, device_config.address)?;
+
+        if device_config.allow_forwarding {
+            // macOS IP forwarding is a single global sysctl, not per-interface like Linux; remember
+            // the previous value so delete_device can restore it.
+            SAVED_IP_FORWARDING.store(get_ip_forwarding()?, Ordering::SeqCst);
+            set_ip_forwarding(1)?;
+        }
+
+        Ok(())
+    }
+
+    async fn replace_ip_address(
+        &self,
+        device_name: &str,
+        old_address: Ipv4Net,
+        new_address: Ipv4Net,
+    ) -> anyhow::Result<()> {
+        let sock = inet_dgram_socket()?;
+        add_alias(sock.as_fd(), device_name, new_address)?;
+        del_address(sock.as_fd(), device_name, old_address.addr())?;
+        Ok(())
+    }
+
+    async fn new_stats_poller(&self, device_name: &str) -> anyhow::Result<impl StatsPoller + Send + Sync + 'static> {
+        super::stats::MacosStatsPoller::new(device_name)
+    }
+
+    fn is_online(&self) -> bool {
+        // A resolvable route toward the default address is enough signal that we have connectivity.
+        route_socket()
+            .and_then(|sock| route_get(sock.as_fd(), Ipv4Addr::UNSPECIFIED))
+            .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::platform::NetworkInterface;
+
+    #[tokio::test]
+    async fn get_default_ipv4_returns_physical_address() {
+        let ip = super::MacosNetworkInterface::new()
+            .get_default_ipv4()
+            .await
+            .expect("default IPv4 lookup should succeed without root");
+        println!("get_default_ipv4 = {ip}");
+        assert!(!ip.is_unspecified(), "expected a real address, got {ip}");
+        assert!(!ip.is_loopback(), "expected a non-loopback address, got {ip}");
+    }
+}

--- a/crates/snxcore/src/platform/macos/resolver.rs
+++ b/crates/snxcore/src/platform/macos/resolver.rs
@@ -1,0 +1,86 @@
+use anyhow::anyhow;
+use async_trait::async_trait;
+use system_configuration::{
+    core_foundation::{array::CFArray, base::TCFType, dictionary::CFDictionary, string::CFString},
+    dynamic_store::SCDynamicStoreBuilder,
+};
+use tracing::{debug, warn};
+
+use crate::platform::{ResolverConfig, ResolverConfigurator};
+
+// SCDynamicStore DNS dictionary keys: literal values of the documented kSCPropNetDNS* constants.
+const KEY_SERVER_ADDRESSES: &str = "ServerAddresses";
+const KEY_SEARCH_DOMAINS: &str = "SearchDomains";
+const KEY_SUPPLEMENTAL_MATCH_DOMAINS: &str = "SupplementalMatchDomains";
+
+const STORE_NAME: &str = "snx-rs";
+
+pub struct MacosResolverConfigurator {
+    store_key: String,
+}
+
+fn cf_string_array<I: IntoIterator<Item = String>>(values: I) -> CFArray<CFString> {
+    let items = values.into_iter().map(|s| CFString::new(&s)).collect::<Vec<_>>();
+    CFArray::from_CFTypes(&items)
+}
+
+#[async_trait]
+impl ResolverConfigurator for MacosResolverConfigurator {
+    async fn configure(&self, config: &ResolverConfig) -> anyhow::Result<()> {
+        debug!(
+            "Configuring DNS at {}: servers={:?}, search={:?}, split_dns={}",
+            self.store_key, config.dns_servers, config.search_domains, config.split_dns
+        );
+
+        let store = SCDynamicStoreBuilder::new(STORE_NAME)
+            .build()
+            .ok_or_else(|| anyhow!(i18n::tr!("error-no-service-connection")))?;
+
+        let servers = cf_string_array(config.dns_servers.iter().map(ToString::to_string));
+        let domains = cf_string_array(config.search_domains.iter().map(|d| d.name.clone()));
+
+        // Split DNS publishes a supplemental scoped resolver so only the pushed domains resolve
+        // through the tunnel; otherwise the domains become a global search list.
+        let domain_key = if config.split_dns {
+            KEY_SUPPLEMENTAL_MATCH_DOMAINS
+        } else {
+            KEY_SEARCH_DOMAINS
+        };
+
+        let dns_dict = CFDictionary::from_CFType_pairs(&[
+            (CFString::new(KEY_SERVER_ADDRESSES), servers.into_CFType()),
+            (CFString::new(domain_key), domains.into_CFType()),
+        ])
+        .into_untyped();
+
+        if store.set(self.store_key.as_str(), dns_dict) {
+            Ok(())
+        } else {
+            warn!("Failed to write DNS configuration to {}", self.store_key);
+            Err(anyhow!(i18n::tr!("error-no-service-connection")))
+        }
+    }
+
+    async fn cleanup(&self, _config: &ResolverConfig) -> anyhow::Result<()> {
+        debug!("Cleaning up DNS at {}", self.store_key);
+
+        let store = SCDynamicStoreBuilder::new(STORE_NAME)
+            .build()
+            .ok_or_else(|| anyhow!(i18n::tr!("error-no-service-connection")))?;
+
+        // Cleanup is idempotent: a false result means the key was already gone.
+        if !store.remove(self.store_key.as_str()) {
+            debug!("DNS key {} was already absent", self.store_key);
+        }
+        Ok(())
+    }
+}
+
+pub fn new_resolver_configurator<S>(device: S) -> anyhow::Result<Box<dyn ResolverConfigurator + Send + Sync>>
+where
+    S: AsRef<str>,
+{
+    Ok(Box::new(MacosResolverConfigurator {
+        store_key: format!("State:/Network/Service/snx-rs-{}/DNS", device.as_ref()),
+    }))
+}

--- a/crates/snxcore/src/platform/macos/routing.rs
+++ b/crates/snxcore/src/platform/macos/routing.rs
@@ -1,0 +1,265 @@
+use std::{
+    ffi::CString,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    os::fd::AsFd,
+    sync::Mutex,
+};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use ipnet::{Ipv4Net, Ipv6Net};
+use libc::c_int;
+use tracing::{debug, warn};
+
+use crate::{
+    model::params::TunnelType,
+    platform::{
+        RoutingConfig, RoutingConfigurator,
+        macos::net::{
+            build_route_message, next_seq, route_get, route_socket, send_route_message, sockaddr_dl, sockaddr_in,
+            sockaddr_in6, struct_bytes,
+        },
+    },
+};
+
+struct TrackedRoute {
+    dest: IpAddr,
+    netmask: Option<IpAddr>,
+}
+
+pub struct MacosRoutingConfigurator {
+    device: String,
+    _tunnel_type: TunnelType,
+    added: Mutex<Vec<TrackedRoute>>,
+}
+
+impl MacosRoutingConfigurator {
+    pub fn new<S: AsRef<str>>(device: S, tunnel_type: TunnelType) -> Self {
+        Self {
+            device: device.as_ref().to_owned(),
+            _tunnel_type: tunnel_type,
+            added: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn tunnel_ifindex(&self) -> anyhow::Result<u16> {
+        let name = CString::new(self.device.as_bytes())?;
+        let index = unsafe { libc::if_nametoindex(name.as_ptr()) };
+        if index == 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        Ok(index as u16)
+    }
+
+    fn add_route_via_tunnel(&self, prefix: Ipv4Net) -> anyhow::Result<()> {
+        debug!("Adding route {prefix} via {}", self.device);
+        let dst = sockaddr_in(prefix.network());
+        let gateway = sockaddr_dl(self.tunnel_ifindex()?);
+        let netmask = sockaddr_in(prefix.netmask());
+
+        let msg = build_route_message(
+            libc::RTM_ADD as u8,
+            libc::RTF_UP | libc::RTF_STATIC,
+            next_seq(),
+            &[
+                (libc::RTA_DST, struct_bytes(&dst)),
+                (libc::RTA_GATEWAY, struct_bytes(&gateway)),
+                (libc::RTA_NETMASK, struct_bytes(&netmask)),
+            ],
+        );
+
+        let sock = route_socket()?;
+        match send_route_message(sock.as_fd(), &msg) {
+            // Track only routes this process created; a pre-existing route (EEXIST) must survive
+            // cleanup so we do not delete something the user already had.
+            Ok(()) => self.added.lock().unwrap_or_else(|e| e.into_inner()).push(TrackedRoute {
+                dest: prefix.network().into(),
+                netmask: Some(prefix.netmask().into()),
+            }),
+            Err(e) if e.raw_os_error() == Some(libc::EEXIST) => debug!("Route {prefix} already exists, not tracking"),
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+
+    fn add_host_exclusion(&self, destination: Ipv4Addr, require_gateway: bool) -> anyhow::Result<()> {
+        let sock = route_socket()?;
+        let reply = route_get(sock.as_fd(), destination)?;
+
+        if reply.ifindex == self.tunnel_ifindex()? {
+            debug!("{destination} already resolves via the tunnel; skipping exclusion");
+            return Ok(());
+        }
+
+        let Some(gateway) = reply.gateway.filter(|g| g.len() >= 2) else {
+            if require_gateway {
+                // Full-route mode covers the default with 0.0.0.0/1 + 128.0.0.0/1; without pinning the
+                // gateway outside the tunnel, ESP-to-gateway would route back in, forming an encap loop.
+                return Err(anyhow!(i18n::tr!("error-cannot-determine-ip")));
+            }
+            debug!("No original gateway for {destination}; skipping exclusion");
+            return Ok(());
+        };
+
+        let dst = sockaddr_in(destination);
+        let mut flags = libc::RTF_UP | libc::RTF_STATIC | libc::RTF_HOST;
+        if gateway[1] as c_int == libc::AF_INET {
+            flags |= libc::RTF_GATEWAY;
+        }
+
+        let msg = build_route_message(
+            libc::RTM_ADD as u8,
+            flags,
+            next_seq(),
+            &[
+                (libc::RTA_DST, struct_bytes(&dst)),
+                (libc::RTA_GATEWAY, gateway.as_slice()),
+            ],
+        );
+
+        match send_route_message(sock.as_fd(), &msg) {
+            Ok(()) => self.added.lock().unwrap_or_else(|e| e.into_inner()).push(TrackedRoute {
+                dest: destination.into(),
+                netmask: None,
+            }),
+            Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                debug!("Host route {destination} already exists, not tracking")
+            }
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+
+    // Blackhole an IPv6 prefix through the routing socket to prevent v6 leaks past the IPv4 tunnel.
+    fn add_blackhole_v6(&self, prefix: Ipv6Net) -> anyhow::Result<()> {
+        debug!("Adding IPv6 blackhole route {prefix}");
+        let dst = sockaddr_in6(prefix.network());
+        // RTF_BLACKHOLE drops matching packets; the gateway is unused but the entry still needs one.
+        let gateway = sockaddr_in6(Ipv6Addr::LOCALHOST);
+        let netmask = sockaddr_in6(prefix.netmask());
+
+        let msg = build_route_message(
+            libc::RTM_ADD as u8,
+            libc::RTF_UP | libc::RTF_STATIC | libc::RTF_GATEWAY | libc::RTF_BLACKHOLE,
+            next_seq(),
+            &[
+                (libc::RTA_DST, struct_bytes(&dst)),
+                (libc::RTA_GATEWAY, struct_bytes(&gateway)),
+                (libc::RTA_NETMASK, struct_bytes(&netmask)),
+            ],
+        );
+
+        let sock = route_socket()?;
+        match send_route_message(sock.as_fd(), &msg) {
+            Ok(()) => self.added.lock().unwrap_or_else(|e| e.into_inner()).push(TrackedRoute {
+                dest: prefix.network().into(),
+                netmask: Some(prefix.netmask().into()),
+            }),
+            Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                debug!("IPv6 blackhole route {prefix} already exists, not tracking")
+            }
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+
+    fn delete_all(&self) {
+        let routes = std::mem::take(&mut *self.added.lock().unwrap_or_else(|e| e.into_inner()));
+        if routes.is_empty() {
+            return;
+        }
+
+        let sock = match route_socket() {
+            Ok(sock) => sock,
+            Err(e) => {
+                warn!("Cannot open route socket for cleanup: {e}");
+                return;
+            }
+        };
+
+        for route in routes {
+            let mut flags = libc::RTF_UP | libc::RTF_STATIC;
+            let msg = match route.dest {
+                IpAddr::V4(dest) => {
+                    let dst = sockaddr_in(dest);
+                    let mask = match route.netmask {
+                        Some(IpAddr::V4(m)) => Some(sockaddr_in(m)),
+                        _ => None,
+                    };
+                    let mut parts: Vec<(c_int, &[u8])> = vec![(libc::RTA_DST, struct_bytes(&dst))];
+                    match &mask {
+                        Some(mask) => parts.push((libc::RTA_NETMASK, struct_bytes(mask))),
+                        None => flags |= libc::RTF_HOST,
+                    }
+                    build_route_message(libc::RTM_DELETE as u8, flags, next_seq(), &parts)
+                }
+                IpAddr::V6(dest) => {
+                    let dst = sockaddr_in6(dest);
+                    let mask = match route.netmask {
+                        Some(IpAddr::V6(m)) => Some(sockaddr_in6(m)),
+                        _ => None,
+                    };
+                    let mut parts: Vec<(c_int, &[u8])> = vec![(libc::RTA_DST, struct_bytes(&dst))];
+                    match &mask {
+                        Some(mask) => parts.push((libc::RTA_NETMASK, struct_bytes(mask))),
+                        None => flags |= libc::RTF_HOST,
+                    }
+                    build_route_message(libc::RTM_DELETE as u8, flags, next_seq(), &parts)
+                }
+            };
+
+            match send_route_message(sock.as_fd(), &msg) {
+                Ok(()) => {}
+                Err(e) if matches!(e.raw_os_error(), Some(libc::ESRCH) | Some(libc::ENOENT)) => {}
+                Err(e) => warn!("Failed to delete route {}: {e}", route.dest),
+            }
+        }
+    }
+}
+
+impl Drop for MacosRoutingConfigurator {
+    fn drop(&mut self) {
+        // If configure() fails partway, the caller never stashes us for a later Cleanup, so undo
+        // any routes we installed here. delete_all() is idempotent and tolerates already-gone routes.
+        self.delete_all();
+    }
+}
+
+#[async_trait]
+impl RoutingConfigurator for MacosRoutingConfigurator {
+    async fn configure(&self, config: &RoutingConfig) -> anyhow::Result<()> {
+        match config {
+            RoutingConfig::Full {
+                destination,
+                disable_ipv6,
+            } => {
+                debug!("Configuring full routing via {}", self.device);
+                self.add_host_exclusion(*destination, true)?;
+                // Override the default without deleting it by covering it with two more-specific halves.
+                self.add_route_via_tunnel(Ipv4Net::new(Ipv4Addr::new(0, 0, 0, 0), 1)?)?;
+                self.add_route_via_tunnel(Ipv4Net::new(Ipv4Addr::new(128, 0, 0, 0), 1)?)?;
+
+                if *disable_ipv6 {
+                    // Blackhole all IPv6 to prevent leaks past the IPv4 tunnel. Like the /1 halves
+                    // above, two /1 blackholes win over any existing ::/0 default by longest-prefix
+                    // match, while more-specific ::1/128 and fe80::/10 routes keep loopback and
+                    // link-local working.
+                    self.add_blackhole_v6(Ipv6Net::new(Ipv6Addr::UNSPECIFIED, 1)?)?;
+                    self.add_blackhole_v6(Ipv6Net::new(Ipv6Addr::new(0x8000, 0, 0, 0, 0, 0, 0, 0), 1)?)?;
+                }
+            }
+            RoutingConfig::Split { destination, routes } => {
+                debug!("Configuring split routing via {}", self.device);
+                self.add_host_exclusion(*destination, false)?;
+                for route in routes {
+                    self.add_route_via_tunnel(*route)?;
+                }
+            }
+            RoutingConfig::Cleanup { .. } => {
+                debug!("Cleaning up routing rules for {}", self.device);
+                self.delete_all();
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/snxcore/src/platform/macos/single_instance.rs
+++ b/crates/snxcore/src/platform/macos/single_instance.rs
@@ -1,0 +1,62 @@
+use std::{fs, os::fd::OwnedFd};
+
+use nix::fcntl::{self, Flock, FlockArg, OFlag};
+use nix::sys::stat::Mode;
+
+use crate::platform::SingleInstance;
+
+pub struct MacosSingleInstance {
+    name: String,
+    handle: Option<Flock<OwnedFd>>,
+}
+
+impl MacosSingleInstance {
+    pub fn new<N: AsRef<str>>(name: N) -> anyhow::Result<Self> {
+        let fd = fcntl::open(
+            name.as_ref(),
+            OFlag::O_RDWR | OFlag::O_CREAT,
+            Mode::from_bits_truncate(0o600),
+        )?;
+
+        let handle = Flock::lock(fd, FlockArg::LockExclusiveNonblock).ok();
+
+        Ok(Self {
+            name: name.as_ref().to_owned(),
+            handle,
+        })
+    }
+}
+
+impl Drop for MacosSingleInstance {
+    fn drop(&mut self) {
+        if self.handle.take().is_some() {
+            let _ = fs::remove_file(&self.name);
+        }
+    }
+}
+
+impl SingleInstance for MacosSingleInstance {
+    fn is_single(&self) -> bool {
+        self.handle.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn second_instance_is_rejected() {
+        let path = std::env::temp_dir().join(format!("snx-rs-test-single-instance-{}.lock", std::process::id()));
+        let path = path.to_str().unwrap();
+
+        let a = MacosSingleInstance::new(path).unwrap();
+        assert!(a.is_single());
+
+        let b = MacosSingleInstance::new(path).unwrap();
+        assert!(!b.is_single());
+
+        drop(a);
+        let _ = fs::remove_file(path);
+    }
+}

--- a/crates/snxcore/src/platform/macos/stats.rs
+++ b/crates/snxcore/src/platform/macos/stats.rs
@@ -1,0 +1,191 @@
+use std::{
+    ffi::CString,
+    mem,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use libc::{c_int, c_uint};
+
+use crate::{model::LiveStats, platform::StatsPoller};
+
+const NO_SAMPLE: u64 = u64::MAX;
+const MIN_SAMPLE_NS: u64 = 500_000_000;
+
+// utun interfaces are ephemeral (created per tunnel, destroyed on fd drop, see net.rs), so the
+// raw AF_LINK counters already start at zero for this session and need no baseline subtraction.
+pub struct MacosStatsPoller {
+    device_name: String,
+    anchor: Instant,
+    prev_ns: AtomicU64,
+    prev_rx: AtomicU64,
+    prev_tx: AtomicU64,
+    last_bps_rx: AtomicU64,
+    last_bps_tx: AtomicU64,
+}
+
+impl MacosStatsPoller {
+    pub fn new(device_name: &str) -> anyhow::Result<Self> {
+        read_if_data(device_name)?;
+        Ok(Self {
+            device_name: device_name.to_owned(),
+            anchor: Instant::now(),
+            prev_ns: AtomicU64::new(NO_SAMPLE),
+            prev_rx: AtomicU64::new(0),
+            prev_tx: AtomicU64::new(0),
+            last_bps_rx: AtomicU64::new(0),
+            last_bps_tx: AtomicU64::new(0),
+        })
+    }
+}
+
+#[async_trait]
+impl StatsPoller for MacosStatsPoller {
+    async fn poll(&self) -> anyhow::Result<LiveStats> {
+        let counters = read_if_data(&self.device_name)?;
+
+        let ordering = Ordering::Relaxed;
+        let now_ns = self.anchor.elapsed().as_nanos() as u64;
+        let prev_ns = self.prev_ns.load(ordering);
+        let elapsed_ns = now_ns.saturating_sub(prev_ns);
+
+        let (bps_rx, bps_tx) = if prev_ns == NO_SAMPLE {
+            self.prev_rx.store(counters.bytes_rx, ordering);
+            self.prev_tx.store(counters.bytes_tx, ordering);
+            self.prev_ns.store(now_ns, ordering);
+            (0, 0)
+        } else if elapsed_ns < MIN_SAMPLE_NS {
+            (self.last_bps_rx.load(ordering), self.last_bps_tx.load(ordering))
+        } else {
+            let prev_rx = self.prev_rx.load(ordering);
+            let prev_tx = self.prev_tx.load(ordering);
+            let dt = elapsed_ns as f64 / 1e9;
+            let rates = (
+                (counters.bytes_rx.saturating_sub(prev_rx) as f64 / dt) as u64,
+                (counters.bytes_tx.saturating_sub(prev_tx) as f64 / dt) as u64,
+            );
+            self.last_bps_rx.store(rates.0, ordering);
+            self.last_bps_tx.store(rates.1, ordering);
+            self.prev_rx.store(counters.bytes_rx, ordering);
+            self.prev_tx.store(counters.bytes_tx, ordering);
+            self.prev_ns.store(now_ns, ordering);
+            rates
+        };
+
+        Ok(LiveStats {
+            last_rtt_ms: None,
+            bytes_rx: counters.bytes_rx,
+            bytes_tx: counters.bytes_tx,
+            packets_rx: counters.packets_rx,
+            packets_tx: counters.packets_tx,
+            errors_rx: counters.errors_rx,
+            errors_tx: counters.errors_tx,
+            bps_rx,
+            bps_tx,
+        })
+    }
+}
+
+struct IfCounters {
+    bytes_rx: u64,
+    bytes_tx: u64,
+    packets_rx: u64,
+    packets_tx: u64,
+    errors_rx: u64,
+    errors_tx: u64,
+}
+
+// getifaddrs(3)/if_data only exposes 32-bit ifi_ibytes/ifi_obytes, which wrap at 4 GiB on
+// long-lived tunnels. NET_RT_IFLIST2 is the route-socket sysctl netstat -I and Activity
+// Monitor read for the 64-bit if_data64 counters, so pull straight from that instead.
+fn read_if_data(device_name: &str) -> anyhow::Result<IfCounters> {
+    let cname =
+        CString::new(device_name).map_err(|_| anyhow!(i18n::tr!("error-device-not-found", device = device_name)))?;
+    let index = unsafe { libc::if_nametoindex(cname.as_ptr()) };
+    if index == 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut mib: [c_int; 6] = [libc::CTL_NET, libc::PF_ROUTE, 0, libc::AF_INET, libc::NET_RT_IFLIST2, 0];
+
+    let mut len: usize = 0;
+    if unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as c_uint,
+            std::ptr::null_mut(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut buf = vec![0u8; len];
+    if unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as c_uint,
+            buf.as_mut_ptr().cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    buf.truncate(len);
+
+    // Every route-socket message shares this 4-byte prefix (u16 msglen, u8 version, u8 type),
+    // so peek it before deciding whether to interpret the record as a full if_msghdr2.
+    const RTM_HDR_LEN: usize = 4;
+
+    let mut offset = 0usize;
+    while offset + RTM_HDR_LEN <= buf.len() {
+        let base = unsafe { buf.as_ptr().add(offset) };
+        let msglen = unsafe { base.cast::<u16>().read_unaligned() } as usize;
+        if msglen < RTM_HDR_LEN || offset + msglen > buf.len() {
+            break;
+        }
+        let msg_type = unsafe { *base.add(3) } as c_int;
+        if msg_type == libc::RTM_IFINFO2 && msglen >= mem::size_of::<libc::if_msghdr2>() {
+            let hdr = unsafe { base.cast::<libc::if_msghdr2>().read_unaligned() };
+            if hdr.ifm_index as c_uint == index {
+                let data = hdr.ifm_data;
+                return Ok(IfCounters {
+                    bytes_rx: data.ifi_ibytes,
+                    bytes_tx: data.ifi_obytes,
+                    packets_rx: data.ifi_ipackets,
+                    packets_tx: data.ifi_opackets,
+                    errors_rx: data.ifi_ierrors,
+                    errors_tx: data.ifi_oerrors,
+                });
+            }
+        }
+        offset += msglen;
+    }
+
+    Err(anyhow!(i18n::tr!("error-device-not-found", device = device_name)))
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn poll_lo0_returns_live_stats() {
+        use crate::platform::StatsPoller;
+
+        let poller = super::MacosStatsPoller::new("lo0").expect("lo0 should exist");
+        let stats = poller.poll().await.expect("poll should succeed without root");
+        println!(
+            "lo0: bytes_rx={} bytes_tx={} packets_rx={} packets_tx={}",
+            stats.bytes_rx, stats.bytes_tx, stats.packets_rx, stats.packets_tx
+        );
+        assert!(stats.bytes_rx > 0, "expected lo0 to have carried some traffic");
+        assert!(stats.bytes_tx > 0, "expected lo0 to have carried some traffic");
+    }
+}

--- a/crates/snxcore/src/tunnel/device.rs
+++ b/crates/snxcore/src/tunnel/device.rs
@@ -10,7 +10,15 @@ impl TunDevice {
     pub fn new(name: &str) -> anyhow::Result<Self> {
         let mut config = tun::Configuration::default();
 
+        // macOS utun devices must be named `utunN`; the custom hint is rejected, so let the
+        // kernel assign a name (read back below). Linux/Windows keep honoring the hint.
+        #[cfg(not(target_os = "macos"))]
         config.tun_name(name).up();
+        #[cfg(target_os = "macos")]
+        {
+            let _ = name;
+            config.up();
+        }
 
         let dev = tun::create_as_async(&config)?;
 

--- a/crates/snxcore/src/tunnel/ipsec/imp/udp.rs
+++ b/crates/snxcore/src/tunnel/ipsec/imp/udp.rs
@@ -31,6 +31,12 @@ fn make_channel(socket: UdpSocket, address: SocketAddr) -> (PacketSender, Packet
     let channel = async move {
         let (mut sink, stream) = framed.split();
 
+        // The macOS socket is left unconnected (see the EISCONN note below), so recv_from
+        // accepts datagrams from any source; filter to the known gateway here to match
+        // Linux/Windows, where the connected socket does this filtering in the kernel.
+        #[cfg(target_os = "macos")]
+        let stream = stream.try_filter(move |(_, src)| futures::future::ready(*src == address));
+
         let mut rx = rx_out.map(|v| Ok::<_, std::io::Error>((v, address)));
         let to_wire = sink.send_all(&mut rx);
 
@@ -83,6 +89,10 @@ impl UdpIPsecTunnel {
             .next()
             .ok_or_else(|| anyhow!("Failed to resolve {}", address_str.as_ref()))?;
 
+        // macOS/BSD returns EISCONN if sendto() carries a destination on a connected
+        // UDP socket; UdpFramed always sends with an address, so leave the socket
+        // unconnected there and let send_to carry the target.
+        #[cfg(not(target_os = "macos"))]
         socket.connect(address).await?;
 
         let (sender, receiver) = make_channel(socket, address);

--- a/docs/building.md
+++ b/docs/building.md
@@ -3,10 +3,12 @@
 * Install the required dependencies:
   - Debian/Ubuntu: `sudo apt install build-essential libssl-dev libfontconfig1-dev libsqlite3-dev libgtk-4-dev libwebkitgtk-6.0-dev libsoup-3.0-dev libjavascriptcoregtk-6.0-dev`
   - openSUSE: `sudo zypper install libopenssl-3-devel sqlite3-devel fontconfig-devel gtk4-devel webkit2gtk4-devel`
+  - macOS: Xcode Command Line Tools (`xcode-select --install`) for the C toolchain, and OpenSSL — either the system/Homebrew package (`brew install openssl@3`) or build with `--features snxcore/vendored-openssl`.
   - Other distros: C compiler, OpenSSL, SQLite3, fontconfig, optionally GTK4 and WebKit6 development package
 * Install a recent [Rust compiler](https://rustup.rs)
 * Run `cargo build` to build the debug version, or `cargo build --release` to build the release version.
-* To build a version with mobile access feature and webkit integration, pass the `--features=mobile-access` parameter.
+* To build a version with mobile access feature and webkit integration, pass the `--features=mobile-access` parameter. GTK and WebKit are not available on macOS, so this feature cannot be built there.
+* On macOS, only the CLI crates are supported: `cargo build --release -p snx-rs -p snxctl`. The `snx-rs-gui` frontend is not ported yet.
 
 NOTE: the minimal supported Rust version is 1.88.
 

--- a/docs/dns-configuration.md
+++ b/docs/dns-configuration.md
@@ -23,3 +23,7 @@ will be forwarded through the tunnel. For further explanation, please check [thi
 The `set-routing-domains=true|false` option controls whether to treat all acquired search domains as routing domains.
 
 For container images which have `systemd-resovled` enabled, it may be necessary to disable split DNS via the `no-split-dns=true` option.
+
+## macOS
+
+DNS is configured via the macOS SystemConfiguration framework (`SCDynamicStore`). Split DNS is implemented using scoped and supplemental match domains, the macOS equivalent of systemd-resolved's routing domains.

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,9 +7,9 @@
 * Certificate enrollment and renewal using the command line interface
 * Mobile Access authentication using VPN web portal
 * HSM token authentication
-* GUI frontend with tray icon
-* IPsec tunnel via Linux native kernel XFRM interface or TCPT/TUN transport
+* GUI frontend with tray icon (not available on macOS yet; CLI only)
+* IPsec tunnel via Linux native kernel XFRM interface, or userspace TUN/ESP transport (used on Windows and macOS, where kernel XFRM is not available)
 * Automatic IPsec tunnel reconnection without authentication, via optional parameter
 * SSL tunnel via TUN device
-* Store a password factor in the OS keychain using Secret Service API
+* Store a password factor in the OS keychain using Secret Service API on Linux, or Keychain (Security.framework) on macOS
 * Multiple connection profiles

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,9 +8,15 @@ For NixOS follow the specific [configuration instructions](https://github.com/an
 For Ubuntu/Debian, a DEB package is provided in the release assets.<br/>
 For RPM-based distros (Fedora, CentOS, openSUSE) use the provided RPM package.<br/>
 For Windows, use the msi installer from the release page.<br/>
+For macOS, no packaged installer is provided yet; build from source (see below).<br/>
 For manual installation using .run installer:
 
 1. Download the installer, then: `chmod +x snx-rs-*-linux-x86_64.run`
 2. Install the application: `sudo ./snx-rs-*-linux-x86_64.run`
+
+For macOS, build the release binaries and run under `sudo`:
+
+1. Build the release binaries: `cargo build --release -p snx-rs -p snxctl`
+2. Tunnel setup requires root, so run `snx-rs` (or `snxctl`) with `sudo`.
 
 Signed APT and DNF repositories with the latest release builds are published at [ancwrd1.github.io/snx-rs](https://ancwrd1.github.io/snx-rs/).

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -4,3 +4,9 @@
 * `systemd-resolved` is highly recommended as a global DNS resolver, to avoid sending all DNS traffic to the corporate VPN servers.
 * Optional: GTK 4.10+ and WebKit 6.0+ for the `mobile-access` feature.
 * GNOME desktop: [AppIndicator](https://extensions.gnome.org/extension/615/appindicator-support/) extension. Not needed for Ubuntu.
+
+## macOS
+
+* macOS 11 (Big Sur) or later, Apple Silicon or Intel.
+* Root privileges (`sudo`) are required for tunnel setup.
+* The GUI frontend is not available on macOS yet; use `snx-rs`/`snxctl` from the command line.

--- a/docs/tunnel-types.md
+++ b/docs/tunnel-types.md
@@ -9,5 +9,7 @@ In this case the application will fall back to the proprietary Check Point TCPT 
 
 The `transport-type` option can be used to choose the IPsec transport type manually. The default value is `auto` which will perform autodetection.
 
+macOS has no kernel `xfrm` support, so IPsec always uses the userspace TUN/ESP path there, same as on Windows. The `kernel` value for `transport-type` is not available on macOS; valid values are `auto`, `udp` and `tcpt`.
+
 For older VPN servers or in case IPsec does not work for some reason, the legacy SSL tunnel can be used as well, selected with `tunnel-type=ssl`.
 SSL tunnel has some limitations: it is slower, has no hardware token support and no MFA in combination with the certificates.


### PR DESCRIPTION
This adds experimental macOS support (Apple Silicon and Intel), following the same platform-abstraction approach as the existing Linux and Windows backends. All macOS-specific code lives under `crates/snxcore/src/platform/macos/`.

Like Windows, macOS has no kernel IPsec (xfrm), so IPsec runs over the userspace TUN + ESP path; transport auto-detect selects UDP (NAT-T) or falls back to TCPT. The legacy SSL tunnel works as well.

Networking is done through native macOS APIs, without shelling out to external tools:

- utun device and interface configuration via ioctl (`SIOCAIFADDR`/`SIOCSIFMTU`)
- routing via `PF_ROUTE` routing sockets — split and full-route, with gateway host-exclusion; `disable-ipv6` installs an IPv6 blackhole; `allow-forwarding` toggles `net.inet.ip.forwarding` (saved and restored)
- DNS via SystemConfiguration (`SCDynamicStore`); split DNS through scoped supplemental match domains
- password storage in the Keychain (Security.framework)
- interface statistics via `NET_RT_IFLIST2` (`if_data64`)
- machine id via `gethostuuid`, single-instance guard via `flock`

`get_default_ipv4` enumerates the routing table for the genuine default route so a covering `/1` from another VPN (e.g. a coexisting utun) cannot bind the ESP socket to the wrong interface.

Verified against a live Check Point gateway (IPsec with RADIUS/MFA login): authentication, office-mode addressing, route installation, and traffic across the tunnel. DNS, Keychain, and the routing/default-route hardening are covered by unit tests; `cargo build`, `clippy`, and `cargo test` are green natively on `aarch64-apple-darwin`. This is experimental, so feedback and testing on more setups are very welcome.

Notes:

- CLI only for now — the Slint GUI (`snx-rs-gui`) is not ported to macOS.
- `transport-type=kernel` is not available on macOS (same as Windows); use `auto`/`udp`/`tcpt`.
- No packaged installer or signed binaries yet; build from source.
- Adds a macOS CI job (fmt/clippy/test for the CLI crates only; vendored OpenSSL so it does not depend on the runner's Homebrew layout).
- Docs and CHANGELOG are updated.
