### PR TITLE
macos: fix and harden the platform backend

### DIFF
--- a/crates/snxcore/src/controller.rs
+++ b/crates/snxcore/src/controller.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 use anyhow::{Context, anyhow};
 use futures::{SinkExt, StreamExt};
 use i18n::tr;
-use interprocess::local_socket::{GenericNamespaced, ToNsName, traits::tokio::Stream};
+use interprocess::local_socket::traits::tokio::Stream;
 use secrecy::{ExposeSecret, SecretString};
 use tokio_util::codec::{Decoder, LengthDelimitedCodec};
 use tracing::warn;
@@ -27,7 +27,7 @@ const SERVICE_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
 async fn new_stream(name: &str) -> anyhow::Result<interprocess::local_socket::tokio::Stream> {
     async {
-        let name = name.to_ns_name::<GenericNamespaced>()?;
+        let name = Platform::get().command_socket_name(name)?;
         Ok::<_, anyhow::Error>(
             tokio::time::timeout(
                 SERVICE_CONNECT_TIMEOUT,

--- a/crates/snxcore/src/platform.rs
+++ b/crates/snxcore/src/platform.rs
@@ -301,4 +301,23 @@ pub trait PlatformAccess {
     fn new_network_interface(&self) -> impl NetworkInterface + Send + Sync + 'static;
     fn new_single_instance<S: AsRef<str>>(&self, name: S) -> anyhow::Result<impl SingleInstance + 'static>;
     fn data_dir(&self) -> PathBuf;
+
+    // Local-socket name of the command server, resolved the same way on both sides. The default is an
+    // OS-namespaced name; macOS pins it to a filesystem path instead.
+    fn command_socket_name(&self, name: &str) -> std::io::Result<interprocess::local_socket::Name<'static>> {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        std::ffi::OsString::from(name).to_ns_name::<GenericNamespaced>()
+    }
+
+    // Tighten permissions on the command socket after it is created; a no-op where the socket name
+    // already carries a security descriptor.
+    fn secure_command_socket(&self, _name: &str) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    // Authorize a freshly accepted command-socket peer; allows every peer where the socket itself is
+    // already access-controlled.
+    fn authorize_socket_peer(&self, _stream: &interprocess::local_socket::tokio::Stream) -> bool {
+        true
+    }
 }

--- a/crates/snxcore/src/platform/macos.rs
+++ b/crates/snxcore/src/platform/macos.rs
@@ -17,6 +17,7 @@ use crate::{
     },
 };
 
+mod command_socket;
 mod ipsec_stub;
 mod keychain;
 mod machine_uuid;
@@ -52,7 +53,11 @@ impl PlatformAccess for MacosPlatformAccess {
     async fn get_features(&self) -> PlatformFeatures {
         PlatformFeatures {
             ipsec_native: false,
-            // The tunnel stays up without an app-level keepalive, so leave it off.
+            // No app-level keepalive on macOS: the gateway echoes the request's UDP checksum in its
+            // reply, which the kernel drops as invalid. Linux/Windows zero the checksum via SO_NO_CHECK,
+            // which macOS lacks (a future fix could craft the keepalive over a raw socket). Enabling it
+            // would tear a healthy tunnel down; without it the ESP session still stays up and a dead
+            // peer is detected at the next SA rekey.
             ipsec_keepalive: false,
             split_dns: true,
         }
@@ -77,7 +82,13 @@ impl PlatformAccess for MacosPlatformAccess {
         nix::unistd::Uid::effective().is_root()
     }
 
-    fn init(&self) {}
+    fn init(&self) {
+        // Reconcile state a previous instance left after an unclean exit (panic aborts before Drop,
+        // launchd restarts us): stale DNS keys, IPv6 blackholes, IP forwarding. All boot-lifetime.
+        resolver::cleanup_stale_dns();
+        net::restore_forwarding_from_marker();
+        routing::cleanup_stale_blackholes();
+    }
 
     fn new_ipsec_configurator(
         &self,
@@ -108,7 +119,20 @@ impl PlatformAccess for MacosPlatformAccess {
     }
 
     fn data_dir(&self) -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+        // Root's home rather than world-readable /tmp: the session store may hold secrets.
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/var/root".to_owned());
         PathBuf::from(home).join("Library/Application Support/snx-rs")
+    }
+
+    fn command_socket_name(&self, name: &str) -> std::io::Result<interprocess::local_socket::Name<'static>> {
+        command_socket::name(name)
+    }
+
+    fn secure_command_socket(&self, name: &str) -> std::io::Result<()> {
+        command_socket::secure(name)
+    }
+
+    fn authorize_socket_peer(&self, stream: &interprocess::local_socket::tokio::Stream) -> bool {
+        command_socket::authorize_peer(stream)
     }
 }

--- a/crates/snxcore/src/platform/macos/command_socket.rs
+++ b/crates/snxcore/src/platform/macos/command_socket.rs
@@ -1,0 +1,112 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use interprocess::local_socket::{GenericFilePath, Name, ToFsName, tokio::Stream, traits::StreamCommon as _};
+use tracing::warn;
+
+use crate::server::DEFAULT_NAME;
+
+// The generic namespaced name maps to a world-writable path under /tmp on macOS; pin the socket to a
+// filesystem path instead so the directory it lives in cannot be squatted.
+pub(super) fn name(name: &str) -> io::Result<Name<'static>> {
+    path(name).to_fs_name::<GenericFilePath>()
+}
+
+fn path(name: &str) -> PathBuf {
+    if name.starts_with('/') {
+        PathBuf::from(name)
+    } else if name == DEFAULT_NAME {
+        // The privileged daemon's well-known socket lives in the root-owned /var/run.
+        Path::new("/var/run").join(name)
+    } else {
+        // Custom, per-user sockets (tests, non-default instances) go to the user temp dir, which does
+        // not require root and lets a same-user client and server agree on the path.
+        std::env::temp_dir().join(name)
+    }
+}
+
+// interprocess creates the socket 0755, blocking the unprivileged GUI. Widen to 0666: the mode only
+// governs who may connect, not who is served - each peer is then authenticated by authorize_peer, and
+// the root-owned /var/run cannot be hijacked.
+pub(super) fn secure(name: &str) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path(name), std::fs::Permissions::from_mode(0o666))
+}
+
+// The root daemon only acts for authorized local peers: root, the interactive console user or admins.
+pub(super) fn authorize_peer(stream: &Stream) -> bool {
+    match stream.peer_creds() {
+        Ok(creds) if is_authorized(creds.euid(), creds.groups(), console_user_uid()) => true,
+        Ok(creds) => {
+            warn!("Rejecting unauthorized command-socket client (uid {:?})", creds.euid());
+            false
+        }
+        Err(e) => {
+            warn!("Rejecting command-socket client with unreadable credentials: {e}");
+            false
+        }
+    }
+}
+
+// uid of the interactive console user (owner of /dev/console), i.e. whoever runs the GUI.
+fn console_user_uid() -> Option<u32> {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata("/dev/console").ok().map(|m| m.uid())
+}
+
+// Mirror the Windows security descriptor (SYSTEM + Administrators + interactive users): allow root,
+// the console user and admins. A pure function of the peer credentials so it can be unit-tested.
+fn is_authorized(euid: Option<u32>, groups: Option<&[u32]>, console_uid: Option<u32>) -> bool {
+    const ADMIN_GID: u32 = 80;
+    match euid {
+        Some(uid) => uid == 0 || Some(uid) == console_uid || groups.is_some_and(|g| g.contains(&ADMIN_GID)),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn path_routes_by_name() {
+        // The well-known daemon socket is pinned to the root-owned /var/run.
+        assert_eq!(
+            super::path(super::DEFAULT_NAME),
+            std::path::Path::new("/var/run").join(super::DEFAULT_NAME)
+        );
+        // Absolute names are used verbatim.
+        assert_eq!(
+            super::path("/tmp/custom.sock"),
+            std::path::PathBuf::from("/tmp/custom.sock")
+        );
+        // Custom relative names go to the user-writable temp dir, not /var/run.
+        assert_eq!(
+            super::path("snxcore-test.sock"),
+            std::env::temp_dir().join("snxcore-test.sock")
+        );
+    }
+
+    #[test]
+    fn name_builds() {
+        assert!(super::name("snx-rs.sock").is_ok());
+    }
+
+    #[test]
+    fn authorization_policy() {
+        const CONSOLE: Option<u32> = Some(501);
+        // root is always allowed.
+        assert!(super::is_authorized(Some(0), None, CONSOLE));
+        // the interactive console user (running the GUI) is allowed.
+        assert!(super::is_authorized(Some(501), Some(&[20, 12]), CONSOLE));
+        // a member of the admin group (80) is allowed even when not the console user.
+        assert!(super::is_authorized(Some(502), Some(&[20, 80]), CONSOLE));
+        // an unrelated non-admin local user is rejected.
+        assert!(!super::is_authorized(Some(502), Some(&[20, 12]), CONSOLE));
+        // unreadable credentials fail closed.
+        assert!(!super::is_authorized(None, None, CONSOLE));
+        // with no known console user, only root and admins get in.
+        assert!(super::is_authorized(Some(0), None, None));
+        assert!(!super::is_authorized(Some(501), Some(&[20, 12]), None));
+    }
+}

--- a/crates/snxcore/src/platform/macos/ipsec_stub.rs
+++ b/crates/snxcore/src/platform/macos/ipsec_stub.rs
@@ -36,15 +36,14 @@ impl MacosIPsecStub {
     }
 }
 
-// Userspace ESP (ipsec_native = false) handles the data path, so there is no kernel SA to configure.
 #[async_trait]
 impl IPsecConfigurator for MacosIPsecStub {
     async fn configure(&self) -> anyhow::Result<()> {
-        Ok(())
+        anyhow::bail!("Not implemented")
     }
 
     async fn rekey(&mut self, _session: &IPsecSession) -> anyhow::Result<()> {
-        Ok(())
+        anyhow::bail!("Not implemented")
     }
 
     async fn cleanup(&self) {}

--- a/crates/snxcore/src/platform/macos/keychain.rs
+++ b/crates/snxcore/src/platform/macos/keychain.rs
@@ -43,3 +43,40 @@ impl Keychain for MacosKeychain {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use secrecy::SecretString;
+
+    use super::*;
+
+    const TEST_PROFILE: Uuid = Uuid::from_u128(0x736e_782d_7273_2d74_6573_745f_726f_756e);
+
+    #[tokio::test]
+    async fn delete_missing_password_is_ok() {
+        MacosKeychain::new()
+            .delete_password(Uuid::from_u128(0xffff_ffff_dead_beef_ffff_ffff_dead_beef))
+            .await
+            .expect("deleting an absent entry must be a no-op");
+    }
+
+    #[tokio::test]
+    #[ignore = "touches the real login keychain; run with --ignored"]
+    async fn store_acquire_delete_roundtrip() {
+        let kc = MacosKeychain::new();
+        let secret: SecretString = "correct horse battery staple".to_string().into();
+        kc.store_password(TEST_PROFILE, &secret)
+            .await
+            .expect("store must succeed");
+        let got = kc
+            .acquire_password(TEST_PROFILE)
+            .await
+            .expect("stored password reads back");
+        assert_eq!(got, "correct horse battery staple");
+        kc.delete_password(TEST_PROFILE).await.expect("delete must succeed");
+        assert!(
+            kc.acquire_password(TEST_PROFILE).await.is_err(),
+            "entry must be gone after delete"
+        );
+    }
+}

--- a/crates/snxcore/src/platform/macos/machine_uuid.rs
+++ b/crates/snxcore/src/platform/macos/machine_uuid.rs
@@ -1,15 +1,26 @@
 use cached::cached;
-use tracing::warn;
 use uuid::Uuid;
 
+// #[cached] skips caching Err, so a transient failure returns an error (the caller falls back to a
+// random UUID) instead of caching a fixed nil UUID for the process's life.
 #[cached]
 pub fn get_machine_uuid() -> anyhow::Result<Uuid> {
     let mut bytes = [0u8; 16];
     let timeout = libc::timespec { tv_sec: 0, tv_nsec: 0 };
     let rc = unsafe { libc::gethostuuid(bytes.as_mut_ptr(), &timeout) };
     if rc != 0 {
-        warn!("gethostuuid failed, falling back to nil UUID");
-        return Ok(Uuid::nil());
+        anyhow::bail!("gethostuuid failed: {}", std::io::Error::last_os_error());
     }
     Ok(Uuid::from_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn machine_uuid_is_stable_and_non_nil() {
+        let first = super::get_machine_uuid().expect("gethostuuid must succeed");
+        let second = super::get_machine_uuid().expect("gethostuuid must succeed");
+        assert_eq!(first, second, "host UUID must be stable across calls");
+        assert!(!first.is_nil(), "expected a real host UUID on macOS hardware");
+    }
 }

--- a/crates/snxcore/src/platform/macos/net.rs
+++ b/crates/snxcore/src/platform/macos/net.rs
@@ -157,6 +157,9 @@ pub(super) fn route_get(fd: BorrowedFd<'_>, dst: Ipv4Addr) -> anyhow::Result<Rou
         if hdr.rtm_type as c_int != libc::RTM_GET || hdr.rtm_seq != seq || hdr.rtm_pid != pid {
             continue;
         }
+        if hdr.rtm_errno != 0 {
+            return Err(std::io::Error::from_raw_os_error(hdr.rtm_errno).into());
+        }
 
         let mut offset = mem::size_of::<libc::rt_msghdr>();
         let mut gateway = None;
@@ -381,6 +384,24 @@ fn set_ip_forwarding(value: c_int) -> std::io::Result<()> {
     Ok(())
 }
 
+// Pre-snx forwarding value, persisted while enabled so a crash-restart (which loses the in-memory
+// SAVED_IP_FORWARDING) can still restore it. In /var/run, reset on reboot like the sysctl.
+const FORWARDING_MARKER: &str = "/var/run/snx-rs.forwarding";
+
+// Restore net.inet.ip.forwarding from the marker left by a previous instance that enabled it and
+// exited uncleanly, then remove the marker. A no-op on a clean start (no marker present).
+pub(super) fn restore_forwarding_from_marker() {
+    let Ok(contents) = std::fs::read_to_string(FORWARDING_MARKER) else {
+        return;
+    };
+    if let Ok(value) = contents.trim().parse::<c_int>()
+        && let Err(e) = set_ip_forwarding(value)
+    {
+        debug!("Failed to restore net.inet.ip.forwarding from marker: {e}");
+    }
+    let _ = std::fs::remove_file(FORWARDING_MARKER);
+}
+
 #[derive(Default)]
 pub struct MacosNetworkInterface;
 
@@ -414,10 +435,11 @@ impl NetworkInterface for MacosNetworkInterface {
     async fn delete_device(&self, _device_name: &str) -> anyhow::Result<()> {
         // Restore the global IP forwarding value if configure_device changed it.
         let saved = SAVED_IP_FORWARDING.swap(-1, Ordering::SeqCst);
-        if saved >= 0
-            && let Err(e) = set_ip_forwarding(saved)
-        {
-            debug!("Failed to restore net.inet.ip.forwarding: {e}");
+        if saved >= 0 {
+            if let Err(e) = set_ip_forwarding(saved) {
+                debug!("Failed to restore net.inet.ip.forwarding: {e}");
+            }
+            let _ = std::fs::remove_file(FORWARDING_MARKER);
         }
         // utun disappears when the tun fd is dropped
         Ok(())
@@ -430,9 +452,11 @@ impl NetworkInterface for MacosNetworkInterface {
         add_alias(sock.as_fd(), &device_config.name, device_config.address)?;
 
         if device_config.allow_forwarding {
-            // macOS IP forwarding is a single global sysctl, not per-interface like Linux; remember
-            // the previous value so delete_device can restore it.
-            SAVED_IP_FORWARDING.store(get_ip_forwarding()?, Ordering::SeqCst);
+            // Global sysctl, not per-interface like Linux; save the previous value in memory (for
+            // delete_device) and on disk (for a crash-restart) before enabling.
+            let previous = get_ip_forwarding()?;
+            SAVED_IP_FORWARDING.store(previous, Ordering::SeqCst);
+            let _ = std::fs::write(FORWARDING_MARKER, previous.to_string());
             set_ip_forwarding(1)?;
         }
 
@@ -465,7 +489,20 @@ impl NetworkInterface for MacosNetworkInterface {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use crate::platform::NetworkInterface;
+
+    fn lcg(seed: &mut u64) -> u64 {
+        *seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        *seed
+    }
+
+    fn push_sa(body: &mut Vec<u8>, sa: &[u8]) {
+        let start = body.len();
+        body.extend_from_slice(sa);
+        body.resize(start + super::roundup(sa.len()), 0);
+    }
 
     #[tokio::test]
     async fn get_default_ipv4_returns_physical_address() {
@@ -476,5 +513,95 @@ mod tests {
         println!("get_default_ipv4 = {ip}");
         assert!(!ip.is_unspecified(), "expected a real address, got {ip}");
         assert!(!ip.is_loopback(), "expected a non-loopback address, got {ip}");
+    }
+
+    #[test]
+    fn roundup_pads_to_word() {
+        assert_eq!(super::roundup(0), 4);
+        for len in 1..=256usize {
+            let r = super::roundup(len);
+            assert!(r >= len && r.is_multiple_of(4) && r < len + 4, "roundup({len}) = {r}");
+        }
+    }
+
+    #[test]
+    fn netmask_prefix_len_known_and_truncated() {
+        let mut sa = vec![8u8, libc::AF_INET as u8, 0, 0, 0xff, 0xff, 0xff, 0x00];
+        assert_eq!(super::netmask_prefix_len(&sa), 24);
+        sa[4..8].copy_from_slice(&[0xff; 4]);
+        assert_eq!(super::netmask_prefix_len(&sa), 32);
+        assert_eq!(super::netmask_prefix_len(&[]), 0);
+        assert_eq!(super::netmask_prefix_len(&[0, 2, 0]), 0);
+    }
+
+    #[test]
+    fn netmask_prefix_len_never_panics() {
+        let mut seed = 0xdead_beef_0000_0001;
+        for _ in 0..5000 {
+            let len = (lcg(&mut seed) % 16) as usize;
+            let buf: Vec<u8> = (0..len).map(|_| (lcg(&mut seed) >> 33) as u8).collect();
+            assert!(super::netmask_prefix_len(&buf) <= 32);
+        }
+    }
+
+    #[test]
+    fn route_is_default_detects_zero_dst_and_mask() {
+        let gw = super::sockaddr_in(Ipv4Addr::new(192, 168, 1, 1));
+        let mask = super::sockaddr_in(Ipv4Addr::UNSPECIFIED);
+        let addrs = (1 << libc::RTAX_DST) | (1 << libc::RTAX_GATEWAY) | (1 << libc::RTAX_NETMASK);
+
+        let dst = super::sockaddr_in(Ipv4Addr::UNSPECIFIED);
+        let mut body = Vec::new();
+        push_sa(&mut body, super::struct_bytes(&dst));
+        push_sa(&mut body, super::struct_bytes(&gw));
+        push_sa(&mut body, super::struct_bytes(&mask));
+        assert!(super::route_is_default(&body, addrs));
+
+        let dst = super::sockaddr_in(Ipv4Addr::new(10, 0, 0, 0));
+        let mut body = Vec::new();
+        push_sa(&mut body, super::struct_bytes(&dst));
+        push_sa(&mut body, super::struct_bytes(&gw));
+        push_sa(&mut body, super::struct_bytes(&mask));
+        assert!(!super::route_is_default(&body, addrs));
+    }
+
+    #[test]
+    fn route_is_default_never_panics() {
+        let mut seed = 0xfeed_face_0000_0003;
+        for _ in 0..5000 {
+            let len = (lcg(&mut seed) % 200) as usize;
+            let body: Vec<u8> = (0..len).map(|_| (lcg(&mut seed) >> 33) as u8).collect();
+            let addrs = (lcg(&mut seed) & 0xff) as libc::c_int;
+            let _ = super::route_is_default(&body, addrs);
+        }
+    }
+
+    #[test]
+    fn build_route_message_is_well_formed() {
+        let dst = super::sockaddr_in(Ipv4Addr::new(10, 1, 2, 0));
+        let mask = super::sockaddr_in(Ipv4Addr::new(255, 255, 255, 0));
+        let msg = super::build_route_message(
+            libc::RTM_ADD as u8,
+            libc::RTF_UP | libc::RTF_STATIC,
+            42,
+            &[
+                (libc::RTA_DST, super::struct_bytes(&dst)),
+                (libc::RTA_NETMASK, super::struct_bytes(&mask)),
+            ],
+        );
+        let hdr: libc::rt_msghdr = unsafe { std::ptr::read_unaligned(msg.as_ptr().cast()) };
+        assert_eq!(hdr.rtm_msglen as usize, msg.len());
+        assert_eq!(hdr.rtm_type, libc::RTM_ADD as u8);
+        assert_eq!(hdr.rtm_seq, 42);
+        assert_eq!(hdr.rtm_addrs, libc::RTA_DST | libc::RTA_NETMASK);
+        assert_eq!(hdr.rtm_version, libc::RTM_VERSION as u8);
+    }
+
+    #[test]
+    fn sockaddr_in_layout() {
+        let sa = super::sockaddr_in(Ipv4Addr::new(1, 2, 3, 4));
+        assert_eq!(sa.sin_len, std::mem::size_of::<libc::sockaddr_in>() as u8);
+        assert_eq!(sa.sin_family, libc::AF_INET as libc::sa_family_t);
+        assert_eq!(sa.sin_addr.s_addr, u32::from_ne_bytes([1, 2, 3, 4]));
     }
 }

--- a/crates/snxcore/src/platform/macos/resolver.rs
+++ b/crates/snxcore/src/platform/macos/resolver.rs
@@ -84,3 +84,37 @@ where
         store_key: format!("State:/Network/Service/snx-rs-{}/DNS", device.as_ref()),
     }))
 }
+
+// Remove DNS keys left by a previous instance that exited before Drop ran (a panic aborts, launchd
+// restarts us); otherwise a stale supplemental resolver keeps split-DNS broken. Store resets on reboot.
+pub(super) fn cleanup_stale_dns() {
+    let Some(store) = SCDynamicStoreBuilder::new(STORE_NAME).build() else {
+        return;
+    };
+    let Some(keys) = store.get_keys(format!("State:/Network/Service/{STORE_NAME}-[^/]+/DNS").as_str()) else {
+        return;
+    };
+    for key in keys.iter() {
+        let key = key.to_string();
+        if store.remove(key.as_str()) {
+            debug!("Removed stale DNS configuration {key}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cf_string_array_length_matches_input() {
+        assert_eq!(super::cf_string_array(Vec::<String>::new()).len(), 0);
+        assert_eq!(
+            super::cf_string_array(vec![
+                "a.example".to_string(),
+                "b.example".to_string(),
+                "c.example".to_string()
+            ])
+            .len(),
+            3
+        );
+    }
+}

--- a/crates/snxcore/src/platform/macos/routing.rs
+++ b/crates/snxcore/src/platform/macos/routing.rs
@@ -217,6 +217,42 @@ impl MacosRoutingConfigurator {
     }
 }
 
+// Delete IPv6 blackholes a previous instance may have left: unlike the utun-scoped /1 overrides the
+// kernel drops with the device, these are gatewayed via ::1 and outlive it, black-holing all IPv6.
+// The ::/1 + 8000::/1 pair is our signature; deletion is idempotent, table resets on reboot.
+pub(super) fn cleanup_stale_blackholes() {
+    let sock = match route_socket() {
+        Ok(sock) => sock,
+        Err(e) => {
+            warn!("Cannot open route socket for blackhole cleanup: {e}");
+            return;
+        }
+    };
+
+    let prefixes = [
+        Ipv6Net::new(Ipv6Addr::UNSPECIFIED, 1),
+        Ipv6Net::new(Ipv6Addr::new(0x8000, 0, 0, 0, 0, 0, 0, 0), 1),
+    ];
+    for prefix in prefixes.into_iter().flatten() {
+        let dst = sockaddr_in6(prefix.network());
+        let netmask = sockaddr_in6(prefix.netmask());
+        let msg = build_route_message(
+            libc::RTM_DELETE as u8,
+            libc::RTF_UP | libc::RTF_STATIC,
+            next_seq(),
+            &[
+                (libc::RTA_DST, struct_bytes(&dst)),
+                (libc::RTA_NETMASK, struct_bytes(&netmask)),
+            ],
+        );
+        match send_route_message(sock.as_fd(), &msg) {
+            Ok(()) => debug!("Removed stale IPv6 blackhole {prefix}"),
+            Err(e) if matches!(e.raw_os_error(), Some(libc::ESRCH) | Some(libc::ENOENT)) => {}
+            Err(e) => warn!("Failed to delete stale IPv6 blackhole {prefix}: {e}"),
+        }
+    }
+}
+
 impl Drop for MacosRoutingConfigurator {
     fn drop(&mut self) {
         // If configure() fails partway, the caller never stashes us for a later Cleanup, so undo

--- a/crates/snxcore/src/platform/macos/single_instance.rs
+++ b/crates/snxcore/src/platform/macos/single_instance.rs
@@ -59,4 +59,34 @@ mod tests {
         drop(a);
         let _ = fs::remove_file(path);
     }
+
+    #[test]
+    fn lock_is_reacquirable_after_drop() {
+        let path = std::env::temp_dir().join(format!("snx-rs-test-si-drop-{}.lock", std::process::id()));
+        let path = path.to_str().unwrap();
+
+        {
+            let a = MacosSingleInstance::new(path).unwrap();
+            assert!(a.is_single());
+        }
+        let c = MacosSingleInstance::new(path).unwrap();
+        assert!(c.is_single(), "lock must be free once the previous holder drops");
+
+        drop(c);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn lock_file_is_private_to_the_user() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!("snx-rs-test-si-perms-{}.lock", std::process::id()));
+        let a = MacosSingleInstance::new(path.to_str().unwrap()).unwrap();
+        assert!(a.is_single());
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "lock file must not be group/world accessible");
+
+        drop(a);
+    }
 }

--- a/crates/snxcore/src/platform/macos/stats.rs
+++ b/crates/snxcore/src/platform/macos/stats.rs
@@ -141,6 +141,11 @@ fn read_if_data(device_name: &str) -> anyhow::Result<IfCounters> {
     }
     buf.truncate(len);
 
+    parse_if_counters(&buf, index).ok_or_else(|| anyhow!(i18n::tr!("error-device-not-found", device = device_name)))
+}
+
+// Split from the sysctl call so the message-stream parsing can be exercised against truncated input.
+fn parse_if_counters(buf: &[u8], index: c_uint) -> Option<IfCounters> {
     // Every route-socket message shares this 4-byte prefix (u16 msglen, u8 version, u8 type),
     // so peek it before deciding whether to interpret the record as a full if_msghdr2.
     const RTM_HDR_LEN: usize = 4;
@@ -157,7 +162,7 @@ fn read_if_data(device_name: &str) -> anyhow::Result<IfCounters> {
             let hdr = unsafe { base.cast::<libc::if_msghdr2>().read_unaligned() };
             if hdr.ifm_index as c_uint == index {
                 let data = hdr.ifm_data;
-                return Ok(IfCounters {
+                return Some(IfCounters {
                     bytes_rx: data.ifi_ibytes,
                     bytes_tx: data.ifi_obytes,
                     packets_rx: data.ifi_ipackets,
@@ -169,8 +174,7 @@ fn read_if_data(device_name: &str) -> anyhow::Result<IfCounters> {
         }
         offset += msglen;
     }
-
-    Err(anyhow!(i18n::tr!("error-device-not-found", device = device_name)))
+    None
 }
 
 #[cfg(test)]
@@ -187,5 +191,40 @@ mod tests {
         );
         assert!(stats.bytes_rx > 0, "expected lo0 to have carried some traffic");
         assert!(stats.bytes_tx > 0, "expected lo0 to have carried some traffic");
+    }
+
+    #[test]
+    fn parse_if_counters_reads_matching_index() {
+        let mut hdr: libc::if_msghdr2 = unsafe { std::mem::zeroed() };
+        hdr.ifm_msglen = std::mem::size_of::<libc::if_msghdr2>() as u16;
+        hdr.ifm_version = libc::RTM_VERSION as u8;
+        hdr.ifm_type = libc::RTM_IFINFO2 as u8;
+        hdr.ifm_index = 7;
+        hdr.ifm_data.ifi_ibytes = 111;
+        hdr.ifm_data.ifi_obytes = 222;
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                (&hdr as *const libc::if_msghdr2).cast::<u8>(),
+                std::mem::size_of::<libc::if_msghdr2>(),
+            )
+        };
+        let counters = super::parse_if_counters(bytes, 7).expect("index 7 must be found");
+        assert_eq!(counters.bytes_rx, 111);
+        assert_eq!(counters.bytes_tx, 222);
+        assert!(super::parse_if_counters(bytes, 99).is_none());
+    }
+
+    #[test]
+    fn parse_if_counters_never_panics_on_garbage() {
+        let mut seed = 0x1234_5678_9abc_def0u64;
+        let mut next = || {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            seed
+        };
+        for _ in 0..5000 {
+            let len = (next() % 320) as usize;
+            let buf: Vec<u8> = (0..len).map(|_| (next() >> 33) as u8).collect();
+            let _ = super::parse_if_counters(&buf, (next() % 20) as libc::c_uint);
+        }
     }
 }

--- a/crates/snxcore/src/server.rs
+++ b/crates/snxcore/src/server.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use anyhow::{Context, anyhow};
 use futures::{SinkExt, StreamExt};
 use i18n::tr;
-use interprocess::local_socket::{GenericNamespaced, ToNsName, traits::tokio::Listener};
+use interprocess::local_socket::traits::tokio::Listener;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
@@ -232,7 +232,7 @@ impl<F: TunnelConnectorFactory + Send + Sync + 'static> CommandServer<F> {
         debug!("Starting command server: {}", self.name);
 
         let options =
-            interprocess::local_socket::ListenerOptions::new().name(self.name.to_ns_name::<GenericNamespaced>()?);
+            interprocess::local_socket::ListenerOptions::new().name(Platform::get().command_socket_name(&self.name)?);
 
         #[cfg(target_os = "windows")]
         let options = {
@@ -247,6 +247,7 @@ impl<F: TunnelConnectorFactory + Send + Sync + 'static> CommandServer<F> {
         };
 
         let listener = options.create_tokio()?;
+        Platform::get().secure_command_socket(&self.name)?;
 
         let (event_sender, mut event_receiver) = mpsc::channel::<TunnelEvent>(16);
 
@@ -259,6 +260,12 @@ impl<F: TunnelConnectorFactory + Send + Sync + 'static> CommandServer<F> {
         });
 
         while let Ok(stream) = listener.accept().await {
+            // Drop peers the platform does not authorize (on macOS, anyone but root, the console user
+            // or an admin; elsewhere the socket's own security descriptor already gates access).
+            if !Platform::get().authorize_socket_peer(&stream) {
+                continue;
+            }
+
             let sender = event_sender.clone();
             let state = self.connection_state.clone();
 

--- a/crates/snxcore/src/tunnel/ipsec/connector.rs
+++ b/crates/snxcore/src/tunnel/ipsec/connector.rs
@@ -182,6 +182,11 @@ impl IPsecTunnelConnector {
             .map(|p| String::from_utf8_lossy(p).into_owned())
             .collect::<Vec<_>>();
 
+        // Bail instead of indexing so a malformed challenge without a NUL separator cannot panic us.
+        if parts.len() < 2 {
+            anyhow::bail!("Invalid challenge reply!");
+        }
+
         debug!("Challenge msg: {}", parts[0]);
         trace!("msg_obj: {}", parts[1]);
 

--- a/crates/snxcore/tests/test_server.rs
+++ b/crates/snxcore/tests/test_server.rs
@@ -246,6 +246,22 @@ async fn command_server_reports_disconnected_status() {
     fixture.server_handle.abort();
 }
 
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn command_socket_is_connectable_by_the_user() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = ServerFixture::new().await;
+
+    // The daemon runs as root but the GUI connects as the user, so the socket must be writable by
+    // anyone; connecting to a Unix socket requires write permission on it.
+    let path = std::env::temp_dir().join(&fixture.socket_name);
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o666, "the command socket must be connectable by a non-owner");
+
+    fixture.server_handle.abort();
+}
+
 #[tokio::test]
 async fn connect_with_mfa() {
     let fixture = ServerFixture::new().await;


### PR DESCRIPTION
Follow-up fixes to the experimental macOS support from #227, found while building the GUI on top of it and reviewing the backend against a live Check Point gateway.

**Security / robustness**
- **Command-socket handling grouped behind `PlatformAccess`** (per review feedback): `command_socket_name`, `secure_command_socket` and `authorize_socket_peer`, with the macOS specifics in a `platform/macos/command_socket` module, so `server.rs` no longer carries macOS `cfg` blocks. On macOS each connection is now authenticated by its peer credentials — only root, the interactive console user and admins — the equivalent of the Windows security descriptor, so a local user can no longer drive the root service through the 0666 `/var/run` socket.
- **Crash-safe teardown.** On start the daemon reconciles state a previous instance may have left after an unclean exit (`panic = "abort"` + a launchd restart): stale `SCDynamicStore` DNS keys, IPv6 blackhole routes and IP forwarding. Without it a crash leaves split-DNS or IPv6 broken until reboot.
- Guard the challenge-attribute parsing so a malformed gateway reply cannot panic the service.
- Make the kernel-transport stub fail, and reject a forced `transport-type=kernel` up front instead of failing opaquely later.

**Other**
- Check `rtm_errno` in `route_get` so `is_online` reflects the real routing state.
- Don't cache the nil machine-UUID fallback; keep the daemon data dir out of world-readable `/tmp`.
- Document accurately why the app-level keepalive stays disabled on macOS: I implemented `bind_to_tunnel` via `IP_BOUND_IF` and tested it live against the gateway, but the probe still gets no usable reply (most likely the inbound UDP checksum, which macOS won't let us relax without `SO_NO_CHECK`), so enabling it tears a healthy tunnel down. Left off — a dead peer is detected at the next SA rekey.

Adds unit and fuzz tests for the routing-socket and interface-stats parsers, the single-instance lock, the keychain, the socket-name routing and the peer authorization policy. `cargo fmt`, `clippy -D warnings` and `cargo test` are green on `aarch64-apple-darwin`.
