### PR TITLE
macos: packaging and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,40 @@ jobs:
           name: artifacts-x86_64-windows
           path: target/snx-rs-*.msi
 
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup target add aarch64-apple-darwin
+
+      - name: Build project
+        run: |
+          chmod +x package/macos/build.sh
+          ./package/macos/build.sh
+
+      - name: Package project
+        run: |
+          chmod +x package/macos/package.sh
+          ./package/macos/package.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-aarch64-macos
+          path: |
+            target/snx-rs-*.dmg
+            target/snx-rs-*.pkg
+
   release:
-    needs: [build, build-windows]
+    needs: [build, build-windows, build-macos]
     runs-on: ubuntu-24.04
 
     steps:
@@ -218,6 +250,21 @@ jobs:
               name: msiName,
               data: msiArtifact
             });
+
+            // package/macos/package.sh names artifacts after `git describe`, which
+            // equals tagName exactly on a tagged release build (see package/package.sh
+            // for the same convention on Linux).
+            for (const extension of ["dmg", "pkg"]) {
+              const macosName = `snx-rs-${tagName}-aarch64-apple-darwin.${extension}`;
+              const macosArtifact = fs.readFileSync(`artifacts/${macosName}`);
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.data.id,
+                name: macosName,
+                data: macosArtifact
+              });
+            }
 
             if (tagName.endsWith("-test")) {
               await github.rest.repos.deleteRelease({

--- a/docs/building.md
+++ b/docs/building.md
@@ -3,12 +3,11 @@
 * Install the required dependencies:
   - Debian/Ubuntu: `sudo apt install build-essential libssl-dev libfontconfig1-dev libsqlite3-dev libgtk-4-dev libwebkitgtk-6.0-dev libsoup-3.0-dev libjavascriptcoregtk-6.0-dev`
   - openSUSE: `sudo zypper install libopenssl-3-devel sqlite3-devel fontconfig-devel gtk4-devel webkit2gtk4-devel`
-  - macOS: Xcode Command Line Tools (`xcode-select --install`) for the C toolchain, and OpenSSL — either the system/Homebrew package (`brew install openssl@3`) or build with `--features snxcore/vendored-openssl`.
+  - macOS: Xcode Command Line Tools (`xcode-select --install`) for the C toolchain. Add the target once with `rustup target add aarch64-apple-darwin` (or `x86_64-apple-darwin` on Intel). OpenSSL: either the system/Homebrew package (`brew install openssl@3`) or build with `--features snxcore/vendored-openssl` to avoid the Homebrew dependency, as the release pipeline does (see `package/macos/build.sh`).
   - Other distros: C compiler, OpenSSL, SQLite3, fontconfig, optionally GTK4 and WebKit6 development package
 * Install a recent [Rust compiler](https://rustup.rs)
 * Run `cargo build` to build the debug version, or `cargo build --release` to build the release version.
-* To build a version with mobile access feature and webkit integration, pass the `--features=mobile-access` parameter. GTK and WebKit are not available on macOS, so this feature cannot be built there.
-* On macOS, only the CLI crates are supported: `cargo build --release -p snx-rs -p snxctl`. The `snx-rs-gui` frontend is not ported yet.
+* To build a version with the mobile-access feature and embedded WebKit portal login, pass the `--features=mobile-access` parameter. On Linux this needs the GTK4/WebKit6 packages listed above; macOS and Windows use the system WebView and need no extra packages.
 
 NOTE: the minimal supported Rust version is 1.88.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,15 +8,18 @@ For NixOS follow the specific [configuration instructions](https://github.com/an
 For Ubuntu/Debian, a DEB package is provided in the release assets.<br/>
 For RPM-based distros (Fedora, CentOS, openSUSE) use the provided RPM package.<br/>
 For Windows, use the msi installer from the release page.<br/>
-For macOS, no packaged installer is provided yet; build from source (see below).<br/>
+For macOS, use the `.pkg` installer from the release page (see below).<br/>
 For manual installation using .run installer:
 
 1. Download the installer, then: `chmod +x snx-rs-*-linux-x86_64.run`
 2. Install the application: `sudo ./snx-rs-*-linux-x86_64.run`
 
-For macOS, build the release binaries and run under `sudo`:
+For macOS, install the CLI (`snx-rs`, `snxctl`) and the `com.github.snx-rs` LaunchDaemon from the `.pkg`:
 
-1. Build the release binaries: `cargo build --release -p snx-rs -p snxctl`
-2. Tunnel setup requires root, so run `snx-rs` (or `snxctl`) with `sudo`.
+1. Download `snx-rs-<version>-aarch64-apple-darwin.pkg` from the [releases](https://github.com/ancwrd1/snx-rs/releases/latest) page.
+2. Install it: `sudo installer -pkg snx-rs-*.pkg -target /`. This installs the `snx-rs`/`snxctl` tools and loads the LaunchDaemon (runs as root from a root-owned location, restarts on failure, logs to `/var/log/snx-rs.log`).
+3. The package is ad-hoc signed only (no Apple Developer ID) and not notarized. If Gatekeeper blocks it, right-click → Open once to approve it; a signed and notarized build opens with no prompt.
+4. To uninstall, run the bundled `uninstall.sh` as root: `sudo /Applications/SNX-RS.app/Contents/Resources/uninstall.sh` (it is also included on the `.dmg`).
+5. To build from source instead, see [Building from Sources](building.md). The `.dmg` contains the `SNX-RS` menu-bar app; drag it to Applications.
 
 Signed APT and DNF repositories with the latest release builds are published at [ancwrd1.github.io/snx-rs](https://ancwrd1.github.io/snx-rs/).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -23,6 +23,8 @@ If the desktop environment does not have a dbus SNI interface, use the `--no-tra
 2. Create a configuration file: `$HOME/.config/snx-rs/snx-rs.conf`, with desired [options](https://github.com/ancwrd1/snx-rs/blob/main/docs/options.md).
 3. Connect the tunnel with `snxctl connect` command.
 
+On macOS, the `.pkg` installer's LaunchDaemon starts `snx-rs` in command mode automatically; there is no separate service-enable step.
+
 ## Recommended for laptops: persistent IPsec session
 
 Set `ike-persist=true` and `ike-lifetime=604800` in your config file to skip the full IKE handshake on the next reconnect.

--- a/package/macos/Info.plist
+++ b/package/macos/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>SNX-RS</string>
+    <key>CFBundleDisplayName</key>
+    <string>SNX-RS VPN Client</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.github.snx-rs</string>
+    <key>CFBundleVersion</key>
+    <string>{{version}}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{{version}}</string>
+    <key>CFBundleExecutable</key>
+    <string>snx-rs-gui</string>
+    <key>CFBundleIconFile</key>
+    <string>snx-rs</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/package/macos/build.sh
+++ b/package/macos/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds snx-rs, snxctl and snx-rs-gui for macOS with the lto profile.
+# Set TARGETS to build additional archs, e.g. TARGETS="aarch64-apple-darwin
+# x86_64-apple-darwin"; package.sh can then lipo them into a universal binary.
+#
+# The GUI is built with the mobile-access feature (embedded WebKit for the
+# Mobile Access portal login); it needs no extra system libraries on macOS.
+
+targets="${TARGETS:-aarch64-apple-darwin}"
+
+for target in $targets; do
+    rustup target add "$target"
+    cargo build --target="$target" --profile=lto \
+        -p snx-rs -p snxctl -p snx-rs-gui \
+        --features snxcore/vendored-openssl,snx-rs-gui/mobile-access "$@"
+done

--- a/package/macos/com.github.snx-rs.gui.plist
+++ b/package/macos/com.github.snx-rs.gui.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.github.snx-rs.gui</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/SNX-RS.app/Contents/MacOS/snx-rs-gui</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/package/macos/com.github.snx-rs.plist
+++ b/package/macos/com.github.snx-rs.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.github.snx-rs</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/Application Support/snx-rs/snx-rs</string>
+        <string>-m</string>
+        <string>command</string>
+        <string>-l</string>
+        <string>info</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/snx-rs.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/snx-rs.log</string>
+</dict>
+</plist>

--- a/package/macos/package.sh
+++ b/package/macos/package.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Assembles SNX-RS.app, ad-hoc codesigns it, and builds the .dmg (GUI) and
+# .pkg (CLI + LaunchDaemon) artifacts. Binaries must already be built, e.g.
+# with package/macos/build.sh. Mirrors package/package.sh.
+#
+# Usage: package/macos/package.sh [version]
+# version defaults to `git describe` (same convention as package/package.sh).
+#
+# Set TRIPLE=x86_64-apple-darwin to package that arch instead of the default
+# aarch64-apple-darwin, or TRIPLE=universal to lipo both together (both must
+# already be built under target/<triple>/lto/ first).
+#
+# Ad-hoc signing only (codesign --sign -): there is no Apple Developer ID in
+# this pipeline. Set DEVELOPER_ID_IDENTITY to a real "Developer ID
+# Application: ..." identity to sign for real; a signed and notarized build
+# opens with no prompt. Otherwise the first launch is gated and the user
+# right-clicks -> Open once, which records the approval without disabling
+# Gatekeeper.
+
+basedir="$(cd "$(dirname "$0")/../.." && pwd)"
+target="$basedir/target"
+macos_dir="$basedir/package/macos"
+bundle_id="com.github.snx-rs"
+identity="${DEVELOPER_ID_IDENTITY:--}"
+triple="${TRIPLE:-aarch64-apple-darwin}"
+
+version="${1:-$(git -C "$basedir" describe)}"
+pkg_version="${version#v}"
+
+stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+
+if [ "$triple" = "universal" ]; then
+    bindir="$stage/universal-bin"
+    mkdir -p "$bindir"
+    for app in snx-rs snxctl snx-rs-gui; do
+        lipo -create \
+            "$target/aarch64-apple-darwin/lto/$app" \
+            "$target/x86_64-apple-darwin/lto/$app" \
+            -output "$bindir/$app"
+    done
+else
+    bindir="$target/$triple/lto"
+fi
+
+build_iconset() {
+    local png="$basedir/package/wix/snx-rs.png"
+    if [ ! -f "$png" ]; then
+        echo "no icon source found ($png), packaging SNX-RS.app without an icon" >&2
+        return
+    fi
+    local iconset="$stage/snx-rs.iconset"
+    mkdir -p "$iconset"
+    for size in 16 32 128 256 512; do
+        sips -z "$size" "$size" "$png" --out "$iconset/icon_${size}x${size}.png" >/dev/null
+        sips -z $((size * 2)) $((size * 2)) "$png" --out "$iconset/icon_${size}x${size}@2x.png" >/dev/null
+    done
+    iconutil -c icns "$iconset" -o "$1"
+}
+
+create_app() {
+    echo "Assembling SNX-RS.app" >&2
+
+    if [ ! -f "$bindir/snx-rs-gui" ]; then
+        echo "missing $bindir/snx-rs-gui, build it first (see package/macos/build.sh)" >&2
+        exit 1
+    fi
+
+    local app="$stage/SNX-RS.app"
+    local contents="$app/Contents"
+    mkdir -p "$contents/MacOS" "$contents/Resources"
+
+    install -m 755 "$bindir/snx-rs-gui" "$contents/MacOS/"
+    sed "s/{{version}}/$pkg_version/" "$macos_dir/Info.plist" > "$contents/Info.plist"
+    build_iconset "$contents/Resources/snx-rs.icns"
+    # Ship the uninstaller inside the bundle so users don't have to fetch it from GitHub.
+    install -m 755 "$macos_dir/uninstall.sh" "$contents/Resources/uninstall.sh"
+
+    codesign --force --deep --sign "$identity" "$app"
+
+    echo "$app"
+}
+
+create_dmg() {
+    echo "Packaging .dmg for $triple" >&2
+
+    local app="$1"
+    local name="snx-rs-${version}-${triple}"
+    local dmg_stage="$stage/dmg"
+
+    mkdir -p "$dmg_stage"
+    cp -R "$app" "$dmg_stage/"
+    ln -s /Applications "$dmg_stage/Applications"
+    # Also drop the uninstaller next to the app so it is visible when the .dmg is mounted.
+    install -m 755 "$macos_dir/uninstall.sh" "$dmg_stage/uninstall.sh"
+
+    hdiutil create -volname "SNX-RS" -srcfolder "$dmg_stage" -ov -format UDZO "$target/$name.dmg"
+}
+
+create_pkg() {
+    echo "Packaging .pkg for $triple" >&2
+
+    local name="snx-rs-${version}-${triple}"
+    local payload="$stage/pkg-payload"
+    local scripts="$stage/pkg-scripts"
+    local libexec="$payload/Library/Application Support/snx-rs"
+
+    mkdir -p "$payload/usr/local/bin" "$libexec" "$payload/Library/LaunchDaemons" "$scripts"
+
+    for app in snx-rs snxctl; do
+        if [ ! -f "$bindir/$app" ]; then
+            echo "missing $bindir/$app, build it first (see package/macos/build.sh)" >&2
+            exit 1
+        fi
+    done
+
+    # The root LaunchDaemon runs snx-rs from a root-owned directory rather than the user-writable
+    # Homebrew /usr/local prefix, so it cannot be swapped out to escalate to root. snxctl runs as the
+    # user; the /usr/local/bin/snx-rs symlink is only a convenience (root uses the absolute path).
+    install -m 755 "$bindir/snx-rs" "$libexec/snx-rs"
+    install -m 755 "$bindir/snxctl" "$payload/usr/local/bin/snxctl"
+    ln -s "/Library/Application Support/snx-rs/snx-rs" "$payload/usr/local/bin/snx-rs"
+
+    install -m 644 "$macos_dir/com.github.snx-rs.plist" "$payload/Library/LaunchDaemons/"
+    install -m 755 "$macos_dir/scripts/postinstall" "$scripts/"
+
+    pkgbuild --root "$payload" \
+        --scripts "$scripts" \
+        --identifier "$bundle_id" \
+        --version "$pkg_version" \
+        --install-location / \
+        "$stage/snx-rs-cli.pkg"
+
+    productbuild --package "$stage/snx-rs-cli.pkg" "$target/$name.pkg"
+}
+
+mkdir -p "$target"
+app_path="$(create_app)"
+create_dmg "$app_path"
+create_pkg

--- a/package/macos/scripts/postinstall
+++ b/package/macos/scripts/postinstall
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs as root during .pkg install. Locks down ownership, then loads the LaunchDaemon.
+
+libexec="/Library/Application Support/snx-rs"
+plist=/Library/LaunchDaemons/com.github.snx-rs.plist
+log=/var/log/snx-rs.log
+
+# Pin ownership so the root-run binary cannot be replaced by a non-root user, regardless of the
+# installer's ownership defaults or a group-writable parent.
+chown -R root:wheel "$libexec"
+
+# Pre-create the log root:admin 0640 so daemon diagnostics are not world-readable; launchd appends.
+touch "$log"
+chown root:admin "$log"
+chmod 640 "$log"
+
+launchctl bootout system/com.github.snx-rs 2>/dev/null || true
+launchctl bootstrap system "$plist"
+launchctl enable system/com.github.snx-rs
+
+exit 0

--- a/package/macos/uninstall.sh
+++ b/package/macos/uninstall.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reverses the .pkg built by package/macos/package.sh. Run with sudo.
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "must be run as root (sudo ./uninstall.sh)" >&2
+    exit 1
+fi
+
+echo "Stopping snx-rs daemon"
+launchctl bootout system/com.github.snx-rs 2>/dev/null || true
+
+echo "Removing files"
+rm -f /usr/local/bin/snx-rs /usr/local/bin/snxctl
+rm -f /Library/LaunchDaemons/com.github.snx-rs.plist
+rm -rf "/Library/Application Support/snx-rs"
+rm -rf /Applications/SNX-RS.app
+pkgutil --forget com.github.snx-rs 2>/dev/null || true
+
+echo "Uninstall finished."
+echo "If you installed the optional login item, also remove it with:"
+echo "  launchctl bootout gui/\$(id -u) ~/Library/LaunchAgents/com.github.snx-rs.gui.plist"
+echo "  rm ~/Library/LaunchAgents/com.github.snx-rs.gui.plist"


### PR DESCRIPTION
Adds macOS packaging and a release job. Builds on #230 — `package/macos/build.sh` builds `snx-rs-gui`, so this is best merged after it.

- `build.sh` builds the lto binaries (vendored OpenSSL, `mobile-access`); `package.sh` assembles `SNX-RS.app` into a `.dmg` and the CLI plus a launchd LaunchDaemon into a `.pkg`.
- The LaunchDaemon runs the service in command mode from a root-owned directory (`/Library/Application Support/snx-rs`), not the user-writable Homebrew `/usr/local` prefix, so the root-run binary cannot be replaced to escalate. The `postinstall` script pins ownership (`chown root:wheel`) and creates the log `root:admin` `0640`, so daemon diagnostics are not world-readable.
- **The uninstaller ships with the app** (per review feedback): `package.sh` copies `uninstall.sh` both into the bundle (`Contents/Resources/uninstall.sh`) and onto the `.dmg`, and the docs point there instead of GitHub. Kept in `Resources` rather than `Contents/MacOS` so it doesn't interfere with codesigning the executable.
- Optional per-user login-item LaunchAgent.
- Binaries are ad-hoc signed; without a Developer ID they are not notarized, so the first launch needs a right-click → Open (a signed and notarized build opens with no prompt). Set `DEVELOPER_ID_IDENTITY` to sign for real.
- Adds a macOS job to the release workflow, uploading the `.dmg` and `.pkg`.

Verified locally: `build.sh` + `package.sh` produce a signed `SNX-RS.app` (with the bundled uninstaller) inside the `.dmg` and a `.pkg` whose payload installs the CLI, the service binary under `/Library/Application Support/snx-rs`, and the LaunchDaemon.
