### PR TITLE
Add -F/--mfa-code support to snxctl

### DIFF
--- a/apps/snxctl/src/main.rs
+++ b/apps/snxctl/src/main.rs
@@ -37,11 +37,25 @@ pub struct CmdlineParams {
 #[derive(Parser)]
 enum SnxCommand {
     #[clap(name = "connect", about = "Connect a tunnel")]
-    Connect,
+    Connect {
+        #[clap(
+            long = "mfa-code",
+            short = 'F',
+            help = "MFA code to use in the non-interactive scripts, typically a TOTP code"
+        )]
+        mfa_code: Option<String>,
+    },
     #[clap(name = "disconnect", about = "Disconnect a tunnel")]
     Disconnect,
     #[clap(name = "reconnect", about = "Reconnect a tunnel")]
-    Reconnect,
+    Reconnect {
+        #[clap(
+            long = "mfa-code",
+            short = 'F',
+            help = "MFA code to use in the non-interactive scripts, typically a TOTP code"
+        )]
+        mfa_code: Option<String>,
+    },
     #[clap(name = "status", about = "Show connection status")]
     Status,
     #[clap(name = "info", about = "Show server information")]
@@ -59,9 +73,9 @@ enum SnxCommand {
 impl From<SnxCommand> for ServiceCommand {
     fn from(value: SnxCommand) -> Self {
         match value {
-            SnxCommand::Connect => ServiceCommand::Connect,
+            SnxCommand::Connect { .. } => ServiceCommand::Connect,
             SnxCommand::Disconnect => ServiceCommand::Disconnect,
-            SnxCommand::Reconnect => ServiceCommand::Reconnect,
+            SnxCommand::Reconnect { .. } => ServiceCommand::Reconnect,
             SnxCommand::Status => ServiceCommand::Status,
             SnxCommand::Info | SnxCommand::Completions { .. } => unreachable!("Handled separately in main"),
         }
@@ -113,6 +127,19 @@ async fn main() -> anyhow::Result<()> {
         }
     } else {
         Arc::new(TunnelParams::load(TunnelParams::default_config_path()).unwrap_or_default())
+    };
+
+    let mfa_code = match &params.command {
+        SnxCommand::Connect { mfa_code } | SnxCommand::Reconnect { mfa_code } => mfa_code.clone(),
+        _ => None,
+    };
+
+    let tunnel_params = match mfa_code {
+        Some(mfa_code) if !mfa_code.is_empty() => Arc::new(TunnelParams {
+            mfa_code: Some(mfa_code),
+            ..(*tunnel_params).clone()
+        }),
+        _ => tunnel_params,
     };
 
     let subscriber = tracing_subscriber::fmt()

--- a/crates/snxcore/src/controller.rs
+++ b/crates/snxcore/src/controller.rs
@@ -187,6 +187,11 @@ where
                     && self.mfa_index == params.password_factor
                 {
                     Ok(self.password_from_keychain.expose_secret().to_owned())
+                } else if let Some(ref mfa_code) = params.mfa_code
+                    && !mfa_code.is_empty()
+                    && self.mfa_index != params.password_factor
+                {
+                    Ok(mfa_code.clone())
                 } else {
                     let input = self.prompt.get_secure_input(prompt).await?;
                     Ok(input)

--- a/crates/snxcore/tests/test_server.rs
+++ b/crates/snxcore/tests/test_server.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 const USERNAME: &str = "username";
 const PASSWORD: &str = "challenge";
+const TOTP_CODE: &str = "654321";
 
 #[derive(Clone, Default)]
 struct MockTunnelConnectorFactory;
@@ -152,6 +153,124 @@ impl TunnelConnector for MockTunnelConnector {
     }
 }
 
+#[derive(Clone, Default)]
+struct MockTotpTunnelConnectorFactory;
+
+impl TunnelConnectorFactory for MockTotpTunnelConnectorFactory {
+    async fn new_tunnel_connector(
+        &self,
+        params: Arc<TunnelParams>,
+    ) -> anyhow::Result<Box<dyn TunnelConnector + Send + Sync>> {
+        Ok(Box::new(MockTotpTunnelConnector {
+            params,
+            command_sender: None,
+            password_factor_count: 0,
+        }))
+    }
+
+    fn new_gateway_connector(&self, _params: Arc<TunnelParams>) -> Arc<dyn GatewayConnector + Send + Sync> {
+        Arc::new(MockGatewayConnector)
+    }
+}
+
+struct MockTotpTunnelConnector {
+    params: Arc<TunnelParams>,
+    command_sender: Option<Sender<TunnelCommand>>,
+    // Number of `PasswordInput`-type challenges issued so far (password stage, then totp stage).
+    // Used to fail fast instead of looping forever if a regression causes the wrong input to be
+    // resubmitted at the totp stage (see `challenge_code` below).
+    password_factor_count: usize,
+}
+
+#[async_trait]
+impl TunnelConnector for MockTotpTunnelConnector {
+    async fn authenticate(&mut self) -> anyhow::Result<Arc<TunnelSession>> {
+        Ok(Arc::new(TunnelSession {
+            session_id: "1234".into(),
+            state: SessionState::PendingChallenge(MfaChallenge {
+                mfa_type: MfaType::UserNameInput,
+                prompt: "username".to_string(),
+            }),
+            username: None,
+        }))
+    }
+
+    async fn delete_session(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn restore_session(&mut self) -> anyhow::Result<Arc<TunnelSession>> {
+        anyhow::bail!("mock restore_session not implemented")
+    }
+
+    async fn challenge_code(
+        &mut self,
+        session: Arc<TunnelSession>,
+        user_input: &str,
+    ) -> anyhow::Result<Arc<TunnelSession>> {
+        match user_input {
+            // Only accepted before the password-stage challenge has been issued.
+            USERNAME if self.password_factor_count == 0 => {
+                self.password_factor_count += 1;
+                Ok(Arc::new(TunnelSession {
+                    state: SessionState::PendingChallenge(MfaChallenge {
+                        mfa_type: MfaType::PasswordInput,
+                        prompt: "password".to_string(),
+                    }),
+                    username: None,
+                    ..(*session).clone()
+                }))
+            }
+            // Only accepted right after the password-stage challenge, before the totp-stage one.
+            PASSWORD if self.password_factor_count == 1 => {
+                self.password_factor_count += 1;
+                Ok(Arc::new(TunnelSession {
+                    state: SessionState::PendingChallenge(MfaChallenge {
+                        mfa_type: MfaType::PasswordInput,
+                        prompt: "totp".to_string(),
+                    }),
+                    username: None,
+                    ..(*session).clone()
+                }))
+            }
+            // Only accepted once the totp-stage challenge has been issued. Anything else at this
+            // point (e.g. `PASSWORD` resubmitted due to a regression in factor selection) falls
+            // through to the `_` arm below and bails immediately instead of issuing yet another
+            // challenge, which would otherwise loop forever.
+            TOTP_CODE if self.password_factor_count == 2 => Ok(Arc::new(TunnelSession {
+                state: SessionState::Authenticated(AuthenticatedSession::SslSessionKey("key".to_string())),
+                username: None,
+                ..(*session).clone()
+            })),
+            _ => {
+                anyhow::bail!("invalid user input");
+            }
+        }
+    }
+
+    async fn create_tunnel(
+        &mut self,
+        _session: Arc<TunnelSession>,
+        command_sender: Sender<TunnelCommand>,
+    ) -> anyhow::Result<Box<dyn VpnTunnel + Send>> {
+        self.command_sender = Some(command_sender);
+        Ok(Box::new(MockTunnel {
+            params: self.params.clone(),
+        }))
+    }
+
+    async fn terminate_tunnel(&mut self, signout: bool) -> anyhow::Result<()> {
+        if let Some(sender) = self.command_sender.take() {
+            let _ = sender.send(TunnelCommand::Terminate(signout)).await;
+        }
+        Ok(())
+    }
+
+    async fn handle_tunnel_event(&mut self, _event: TunnelEvent) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 struct MockTunnel {
     params: Arc<TunnelParams>,
 }
@@ -231,6 +350,20 @@ impl ServerFixture {
             server_handle,
         }
     }
+
+    async fn new_with_totp() -> Self {
+        let socket_name = format!("snxcore-test-{}.sock", Uuid::new_v4());
+
+        let server = CommandServer::with_name(&socket_name, MockTotpTunnelConnectorFactory);
+        let server_handle = tokio::spawn(server.run());
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        Self {
+            socket_name,
+            server_handle,
+        }
+    }
 }
 
 #[tokio::test]
@@ -269,6 +402,38 @@ async fn connect_with_mfa() {
     let params = Arc::new(TunnelParams {
         server_name: "127.0.0.1".to_owned(),
         login_type: "vpn_Test".to_string(),
+        ..Default::default()
+    });
+
+    let mut controller =
+        ServiceController::new_with_server_name(&fixture.socket_name, MockPrompt, MockBrowser, Vec::new());
+    let status = controller
+        .command(ServiceCommand::Connect, params.clone())
+        .await
+        .unwrap();
+    match status {
+        ConnectionStatus::Connected(info) => {
+            assert_eq!(info.server_name, params.server_name);
+            assert_eq!(info.username, USERNAME);
+            assert_eq!(info.login_type, params.login_type);
+        }
+        _ => panic!("invalid status"),
+    }
+
+    let status = controller.command(ServiceCommand::Disconnect, params).await.unwrap();
+    assert_eq!(status, ConnectionStatus::Disconnected);
+
+    fixture.server_handle.abort();
+}
+
+#[tokio::test]
+async fn connect_with_totp_mfa_code() {
+    let fixture = ServerFixture::new_with_totp().await;
+
+    let params = Arc::new(TunnelParams {
+        server_name: "127.0.0.1".to_owned(),
+        login_type: "vpn_Test".to_string(),
+        mfa_code: Some(TOTP_CODE.to_string()),
         ..Default::default()
     });
 

--- a/docs/command-line-usage.md
+++ b/docs/command-line-usage.md
@@ -38,9 +38,9 @@ Example output (may differ for your server):
 There are two ways to use the application:
 
 * **Command Mode**: Selected by the `-m command` parameter. In this mode, the application runs as a service without establishing a connection and awaits commands from the external client. Use the `snxctl` utility to send commands to the service. This mode is recommended for desktop usage. The following commands are accepted:
-  - `connect`: Establish a connection. Parameters are taken from the `~/.config/snx-rs/snx-rs.conf` file.
+  - `connect`: Establish a connection. Parameters are taken from the `~/.config/snx-rs/snx-rs.conf` file. Pass `-F`/`--mfa-code <CODE>` to answer a TOTP-style MFA challenge non-interactively instead of being prompted (mirrors the `snx-rs` standalone-mode flag of the same name).
   - `disconnect`: Disconnect a tunnel.
-  - `reconnect`: Drop the connection and then reconnect.
+  - `reconnect`: Drop the connection and then reconnect. Also accepts `-F`/`--mfa-code <CODE>`, same as `connect`.
   - `status`: Show connection status.
   - `info`: Show server authentication methods and supported tunnel types.
   - Run it with the `--help` option to get usage help.


### PR DESCRIPTION
## Summary

- Add `-F` / `--mfa-code <CODE>` to `snxctl connect` and `snxctl reconnect`.
- Pass the supplied code to `ServiceController` for non-interactive TOTP-style MFA challenges.
- Preserve the configured password for the password factor.
- Treat an empty MFA code as absent and fall back to an interactive prompt.
- Document the new CLI options.
- Add an integration test covering username, password, and TOTP authentication.