### PR TITLE
Support config-file MFA codes in command mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v6.2.4 (TBD)
 * macOS: fixed the installer failing to upgrade over a running daemon (#241).
 * macOS: fixed GUI application crash upon exit when windows are still opened (#242).
+* Added `mfa-code` config file option, honored by `snxctl` in command mode, not only the `--mfa-code` CLI flag of the standalone `snx-rs` binary.
 
 ## v6.2.3 (2026-08-01)
 * Windows, macOS: fixed the status window being displayed too narrow.

--- a/crates/snxcore/src/controller.rs
+++ b/crates/snxcore/src/controller.rs
@@ -187,6 +187,10 @@ where
                     && self.mfa_index == params.password_factor
                 {
                     Ok(self.password_from_keychain.expose_secret().to_owned())
+                } else if let Some(ref mfa_code) = params.mfa_code
+                    && self.mfa_index != params.password_factor
+                {
+                    Ok(mfa_code.clone())
                 } else {
                     let input = self.prompt.get_secure_input(prompt).await?;
                     Ok(input)

--- a/crates/snxcore/src/model/params.rs
+++ b/crates/snxcore/src/model/params.rs
@@ -657,6 +657,7 @@ impl TunnelParams {
                 "allow-forwarding" => params.allow_forwarding = v.parse().unwrap_or_default(),
                 "tls-version-max" => params.tls_version_max = v.parse().unwrap_or_default(),
                 "client-logging-data" => params.client_logging_data = Some(v.into()),
+                "mfa-code" => params.mfa_code = Some(v),
                 other => {
                     warn!("Ignoring unknown option: {}", other);
                 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -42,6 +42,7 @@
 | `allow-forwarding=true\|false`            | Enable or disable packet forwarding for the tunnel interface. Default is false.                                                                          |
 | `tls-version-max=1.2\|1.3\|default`       | Maximum TLS version offered to the gateway. Default is `1.2` to work around gateways that hang on TLS 1.3 ClientHellos. Use `default` to remove the cap. |
 | `client-logging-data=<path>`              | A path to a json file which contains a custom client_logging_data structure (*). Used to impersonate the official Check Point client.                    |
+| `mfa-code=<code>`                         | MFA code to use in non-interactive scripts, typically a TOTP code. Never written back on save; add/remove it manually in the config file.                |
 
 
 (*) client_logging_data structure, all fields are optional:


### PR DESCRIPTION
Load mfa-code from connection profiles and use it for non-password authentication factors in snxctl. Keep the code out of saved profile files.